### PR TITLE
Moved 3D views to dockable windows

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -66,8 +66,6 @@ private slots:
 
     void on_actionImportGates_triggered();
 
-    void onPlotArea_expand(QPoint pos, QPoint angleDelta);
-
 private:
     typedef enum {
         Time,
@@ -107,6 +105,13 @@ private:
     QVector< DataPoint >  m_waypoints;
 
     double                m_timeStep;
+
+    DataView             *mLeftView;
+    DataView             *mTopView;
+    DataView             *mFrontView;
+
+    void writeSettings();
+    void readSettings();
 
     void initPlot();
     void initViews();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -14,22 +14,9 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QSplitter" name="vSplitter">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <widget class="DataPlot" name="plotArea" native="true"/>
-      <widget class="QSplitter" name="hSplitter">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <widget class="DataView" name="leftView" native="true"/>
-       <widget class="DataView" name="topView" native="true"/>
-       <widget class="DataView" name="frontView" native="true"/>
-      </widget>
-     </widget>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="DataPlot" name="plotArea" native="true"/>
     </item>
    </layout>
   </widget>
@@ -86,11 +73,20 @@
     <addaction name="actionZoom"/>
     <addaction name="actionMeasure"/>
    </widget>
+   <widget class="QMenu" name="menuWindow">
+    <property name="title">
+     <string>Window</string>
+    </property>
+    <addaction name="actionShowLeftView"/>
+    <addaction name="actionShowTopView"/>
+    <addaction name="actionShowFrontView"/>
+   </widget>
    <addaction name="menu_File"/>
    <addaction name="menuPlots"/>
    <addaction name="menuDomain"/>
    <addaction name="menuUnits"/>
    <addaction name="menu_Tools"/>
+   <addaction name="menuWindow"/>
   </widget>
   <action name="actionImport">
    <property name="text">
@@ -251,6 +247,39 @@
     <string>M</string>
    </property>
   </action>
+  <action name="actionShowLeftView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Side View</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+1</string>
+   </property>
+  </action>
+  <action name="actionShowTopView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>T&amp;op View</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+2</string>
+   </property>
+  </action>
+  <action name="actionShowFrontView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Front View</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+3</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -258,12 +287,6 @@
    <class>DataPlot</class>
    <extends>QWidget</extends>
    <header>dataplot.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>DataView</class>
-   <extends>QWidget</extends>
-   <header>dataview.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Previously, the three 3D views were displayed using a "splitter" which divided the main window into four parts--one part on the top for the plots and three on the bottom for the 3D views. However, this has a few limitations:
- The views are not labeled.
- The views cannot be rearranged.
- This method does not extend well to additional tools.

For these reasons, I have moved the 3D views to dockable windows, By default these are docked on the bottom of the main window, and appear similarly to previous versions. The position of the 3D views is persistent, so that they come up in the same place when the program is re-opened.
