### PR TITLE
Add 'set zero' and 'set ground' tools

### DIFF
--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -39,6 +39,10 @@ void DataPlot::mouseReleaseEvent(
     {
         emit zero(xAxis->pixelToCoord(endPos.x()));
     }
+    if (m_dragging && m_tool == Ground)
+    {
+        emit ground(xAxis->pixelToCoord(endPos.x()));
+    }
 
     if (m_dragging)
     {

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -9,7 +9,7 @@ class DataPlot : public QCustomPlot
 
 public:
     typedef enum {
-        Pan, Zoom, Measure, Zero
+        Pan, Zoom, Measure, Zero, Ground
     } Tool;
 
     explicit DataPlot(QWidget *parent = 0);
@@ -40,6 +40,7 @@ signals:
     void pan(double xBegin, double xEnd);
     void measure(double xBegin, double xEnd);
     void zero(double xMark);
+    void ground(double xMark);
 
     void mark(double xMark);
     void clear();

--- a/src/datapoint.cpp
+++ b/src/datapoint.cpp
@@ -23,6 +23,7 @@ DataPoint interpolate(const DataPoint &p1,
     ret.x = p1.x + a * (p2.x - p1.x);
     ret.y = p1.y + a * (p2.y - p1.y);
     ret.z = p1.z + a * (p2.z - p1.z);
+    ret.alt = p1.alt + a * (p2.alt - p1.alt);
 
     ret.dist2D = p1.dist2D + a * (p2.dist2D - p1.dist2D);
     ret.dist3D = p1.dist3D + a * (p2.dist3D - p1.dist3D);

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -20,6 +20,7 @@ public:
     double      x;
     double      y;
     double      z;
+    double      alt;
 
     double      dist2D;
     double      dist3D;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -44,6 +44,7 @@ private slots:
     void on_actionZoom_triggered();
     void on_actionMeasure_triggered();
     void on_actionZero_triggered();
+    void on_actionGround_triggered();
 
     void on_actionTime_triggered();
     void on_actionDistance2D_triggered();
@@ -53,6 +54,7 @@ private slots:
     void onDataPlot_pan(double xBegin, double xEnd);
     void onDataPlot_measure(double xBegin, double xEnd);
     void onDataPlot_zero(double xMark);
+    void onDataPlot_ground(double xMark);
 
     void onDataPlot_mark(double xMark);
     void onDataPlot_clear();    

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -79,7 +79,9 @@
     <addaction name="actionPan"/>
     <addaction name="actionZoom"/>
     <addaction name="actionMeasure"/>
+    <addaction name="separator"/>
     <addaction name="actionZero"/>
+    <addaction name="actionGround"/>
    </widget>
    <widget class="QMenu" name="menuWindow">
     <property name="title">
@@ -315,10 +317,21 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Zer&amp;o</string>
+    <string>Set Zer&amp;o</string>
    </property>
    <property name="shortcut">
     <string>0</string>
+   </property>
+  </action>
+  <action name="actionGround">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Set Grou&amp;nd</string>
+   </property>
+   <property name="shortcut">
+    <string>N</string>
    </property>
   </action>
  </widget>

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -85,8 +85,8 @@ public:
     const QColor color() { return Qt::black ; }
     double value(const DataPoint &dp, Units units)
     {
-        if (units == Metric) return dp.z;
-        else                 return dp.z * METERS_TO_FEET;
+        if (units == Metric) return dp.alt;
+        else                 return dp.alt * METERS_TO_FEET;
     }
 };
 


### PR DESCRIPTION
Added two new tools: `Set Zero` and `Set Ground`.

The `Set Zero` tool sets the 'zero' point for the following values:
- x, y and z (used in the 3D plots at the bottom)
- t, 2D distance and 3D distance (used as x axes)

The `Set Ground` tool sets the ground level for the elevation calculation.

Both tools are momentary. As soon as the user clicks, the tool returns to what was previously selected.
