### PR TITLE
Change 'zero' to 'exit' and update shortcut key.

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -317,10 +317,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Set Zer&amp;o</string>
+    <string>Set E&amp;xit</string>
    </property>
    <property name="shortcut">
-    <string>0</string>
+    <string>X</string>
    </property>
   </action>
   <action name="actionGround">


### PR DESCRIPTION
Most of the time, the "zero" point for time and distance will correspond with the exit, so I thought it would be better to name it appropriately.
