### PR TITLE
Added hack for single-key shortcuts on Mac

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QSettings>
+#include <QShortcut>
 #include <QToolTip>
 
 #include "configdialog.h"
@@ -31,6 +32,20 @@ MainWindow::MainWindow(
 
     // Restore window state
     readSettings();
+
+#ifdef Q_OS_MAC
+    // Single key shortcuts on Mac
+    foreach (QAction *a, m_ui->menuPlots->actions())
+    {
+        QObject::connect(new QShortcut(a->shortcut(), a->parentWidget()),
+                         SIGNAL(activated()), a, SLOT(trigger()));
+    }
+    foreach (QAction *a, m_ui->menu_Tools->actions())
+    {
+        QObject::connect(new QShortcut(a->shortcut(), a->parentWidget()),
+                         SIGNAL(activated()), a, SLOT(trigger()));
+    }
+#endif
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Single-key shortcuts don't work as expected on Mac. See this explanation:

http://thebreakfastpost.com/2014/06/03/single-key-menu-shortcuts-with-qt5-on-osx/

To fix the problem, a hack introduced in that article is implemented.
