### PR TITLE
Simplified Windows icon handling

### DIFF
--- a/src/FlySightViewer.pro
+++ b/src/FlySightViewer.pro
@@ -33,4 +33,4 @@ HEADERS  += mainwindow.h \
 FORMS    += mainwindow.ui \
     configdialog.ui
 
-RC_FILE += FlySightViewer.rc
+RC_ICONS = FlySightViewer.ico

--- a/src/FlySightViewer.rc
+++ b/src/FlySightViewer.rc
@@ -1,1 +1,0 @@
-IDI_ICON1               ICON    DISCARDABLE     "FlySightViewer.ico"


### PR DESCRIPTION
Changed to `RC_ICONS` method of supplying Windows application icon.
