### PR TITLE
Better defaults for window layout and units

### DIFF
--- a/src/dataview.cpp
+++ b/src/dataview.cpp
@@ -5,3 +5,9 @@ DataView::DataView(QWidget *parent) :
 {
 
 }
+
+QSize DataView::sizeHint() const
+{
+    // Keeps windows from being intialized as very short
+    return QSize(175, 175);
+}

--- a/src/dataview.h
+++ b/src/dataview.h
@@ -9,7 +9,9 @@ class DataView : public QCustomPlot
 
 public:
     explicit DataView(QWidget *parent = 0);
-    
+
+    virtual QSize sizeHint() const;
+
 signals:
     
 public slots:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -30,14 +30,14 @@ MainWindow::MainWindow(
                      this, SLOT(close()));
 #endif
 
-    // Restore window state
-    readSettings();
-
     // Intitialize plot area
     initPlot();
 
     // Initialize 3D views
     initViews();
+
+    // Restore window state
+    readSettings();
 
 #ifdef Q_OS_MAC
     // Fix for single-key shortcuts on Mac
@@ -89,8 +89,8 @@ void MainWindow::readSettings()
     settings.beginGroup("mainWindow");
     restoreGeometry(settings.value("geometry").toByteArray());
     restoreState(settings.value("state").toByteArray());
-    m_units = (PlotValue::Units) settings.value("units").toInt();
-    m_xAxis = (XAxisType) settings.value("xAxis").toInt();
+    m_units = (PlotValue::Units) settings.value("units", m_units).toInt();
+    m_xAxis = (XAxisType) settings.value("xAxis", m_xAxis).toInt();
     settings.endGroup();
 }
 

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -25,7 +25,7 @@ public:
         Imperial
     } Units;
 
-    PlotValue(): mVisible(false) {}
+    PlotValue(bool visible = false): mVisible(visible) {}
 
     virtual const QString title(Units units) = 0;
     virtual const QColor color() = 0;
@@ -50,7 +50,7 @@ public:
     {
         QSettings settings("FlySight", "Viewer");
         settings.beginGroup("plotValue/" + key());
-        mVisible = settings.value("visible").toBool();
+        mVisible = settings.value("visible", mVisible).toBool();
         settings.endGroup();
     }
 
@@ -76,7 +76,7 @@ class PlotElevation: public PlotValue
     Q_OBJECT
 
 public:
-    PlotElevation() {}
+    PlotElevation(): PlotValue(true) {}
     const QString title(Units units)
     {
         if (units == Metric) return tr("Elevation (m)");


### PR DESCRIPTION
Added better defaults for:
- 3D view size;
- Metric/imperial units;
- Plot axes.

Also moved `readSettings` after window intialization in the `MainWindow` constructor. This prevents initialization from overriding the stored settings.
