### PR TITLE
Added wind estimation tools

### DIFF
--- a/src/FlySightViewer.pro
+++ b/src/FlySightViewer.pro
@@ -21,7 +21,8 @@ SOURCES += main.cpp \
     configdialog.cpp \
     mapview.cpp \
     common.cpp \
-    videoview.cpp
+    videoview.cpp \
+    windplot.cpp
 
 HEADERS  += mainwindow.h \
     qcustomplot.h \
@@ -33,7 +34,8 @@ HEADERS  += mainwindow.h \
     configdialog.h \
     mapview.h \
     common.h \
-    videoview.h
+    videoview.h \
+    windplot.h
 
 FORMS    += mainwindow.ui \
     configdialog.ui \

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -10,6 +10,8 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     // Add page
     ui->contentsWidget->addItems(
                 QStringList() << tr("General"));
+    ui->contentsWidget->addItems(
+                QStringList() << tr("Wind"));
 
     // Add units
     ui->unitsCombo->addItems(
@@ -19,6 +21,9 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     connect(ui->contentsWidget,
             SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)),
             this, SLOT(changePage(QListWidgetItem*,QListWidgetItem*)));
+
+    // Go to first page
+    ui->contentsWidget->setCurrentRow(0);
 }
 
 ConfigDialog::~ConfigDialog()
@@ -26,7 +31,7 @@ ConfigDialog::~ConfigDialog()
     delete ui;
 }
 
-void ConfigDialog::ChangePage(
+void ConfigDialog::changePage(
         QListWidgetItem *current,
         QListWidgetItem *previous)
 {
@@ -44,4 +49,15 @@ void ConfigDialog::setUnits(
 PlotValue::Units ConfigDialog::units() const
 {
     return (PlotValue::Units) ui->unitsCombo->currentIndex();
+}
+
+void ConfigDialog::setDtWind(
+        double dtWind)
+{
+    ui->dtWindEdit->setText(QString("%1").arg(dtWind));
+}
+
+double ConfigDialog::dtWind() const
+{
+    return ui->dtWindEdit->text().toDouble();
 }

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -21,11 +21,14 @@ public:
     void setUnits(PlotValue::Units units);
     PlotValue::Units units() const;
 
+    void setDtWind(double dtWind);
+    double dtWind() const;
+
 private:
     Ui::ConfigDialog *ui;
 
 private slots:
-    void ChangePage(QListWidgetItem *current, QListWidgetItem *previous);
+    void changePage(QListWidgetItem *current, QListWidgetItem *previous);
 };
 
 #endif // CONFIGDIALOG_H

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -31,51 +31,84 @@
        <item>
         <widget class="QStackedWidget" name="pagesWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="page">
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="0" column="0">
-            <layout class="QVBoxLayout" name="verticalLayout_2">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>Units:</string>
-                 </property>
-                 <property name="buddy">
-                  <cstring>unitsCombo</cstring>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="unitsCombo">
-                 <property name="currentText">
-                  <string/>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label">
+               <property name="text">
+                <string>Units:</string>
+               </property>
+               <property name="buddy">
+                <cstring>unitsCombo</cstring>
+               </property>
+              </widget>
              </item>
              <item>
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
+              <widget class="QComboBox" name="unitsCombo">
+               <property name="currentText">
+                <string/>
                </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
+              </widget>
              </item>
             </layout>
            </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>200</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="page_2"/>
+         <widget class="QWidget" name="page_2">
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Window size:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="dtWindEdit"/>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>s</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>200</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -65,6 +65,9 @@ void DataPlot::initPlot()
     m_yValues.append(new PlotVerticalAccuracy);
     m_yValues.append(new PlotSpeedAccuracy);
     m_yValues.append(new PlotNumberOfSatellites);
+    m_yValues.append(new PlotWindSpeed);
+    m_yValues.append(new PlotWindDirection);
+    m_yValues.append(new PlotAircraftSpeed);
 
     foreach (PlotValue *v, m_yValues)
     {

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -68,6 +68,7 @@ void DataPlot::initPlot()
     m_yValues.append(new PlotWindSpeed);
     m_yValues.append(new PlotWindDirection);
     m_yValues.append(new PlotAircraftSpeed);
+    m_yValues.append(new PlotWindError);
 
     foreach (PlotValue *v, m_yValues)
     {

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -359,10 +359,7 @@ void DataPlot::setMark(
     if (mMainWindow->dataSize() == 0) return;
 
     DataPoint dp = interpolateDataX(mark);
-
     mMainWindow->setMark(dp.t);
-
-    if (mMainWindow->dataSize() == 0) return;
 
     QString status;
     status = QString("<table width='200'>");

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -544,27 +544,37 @@ DataPoint DataPlot::interpolateDataX(
 int DataPlot::findIndexBelowX(
         double x)
 {
-    for (int i = 0; i < mMainWindow->dataSize(); ++i)
+    int below = -1;
+    int above = mMainWindow->dataSize();
+
+    while (below + 1 != above)
     {
-        const DataPoint &dp = mMainWindow->dataPoint(i);
-        if (xValue()->value(dp, mMainWindow->units()) > x)
-            return i - 1;
+        int mid = (below + above) / 2;
+        const DataPoint &dp = mMainWindow->dataPoint(mid);
+
+        if (xValue()->value(dp, mMainWindow->units()) < x) below = mid;
+        else                                               above = mid;
     }
 
-    return mMainWindow->dataSize() - 1;
+    return below;
 }
 
 int DataPlot::findIndexAboveX(
         double x)
 {
-    for (int i = mMainWindow->dataSize() - 1; i >= 0; --i)
+    int below = -1;
+    int above = mMainWindow->dataSize();
+
+    while (below + 1 != above)
     {
-        const DataPoint &dp = mMainWindow->dataPoint(i);
-        if (xValue()->value(dp, mMainWindow->units()) <= x)
-            return i + 1;
+        int mid = (below + above) / 2;
+        const DataPoint &dp = mMainWindow->dataPoint(mid);
+
+        if (xValue()->value(dp, mMainWindow->units()) > x) above = mid;
+        else                                               below = mid;
     }
 
-    return 0;
+    return above;
 }
 
 void DataPlot::togglePlot(

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -30,6 +30,9 @@ public:
         VerticalAccuracy,
         SpeedAccuracy,
         NumberOfSatellites,
+        WindSpeed,
+        WindDirection,
+        AircraftSpeed,
         yaLast
     } YAxisType;
 

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -33,6 +33,7 @@ public:
         WindSpeed,
         WindDirection,
         AircraftSpeed,
+        WindError,
         yaLast
     } YAxisType;
 

--- a/src/datapoint.cpp
+++ b/src/datapoint.cpp
@@ -41,6 +41,7 @@ DataPoint DataPoint::interpolate(
     ret.windE = p1.windE + a * (p2.windE - p1.windE);
     ret.windN = p1.windN + a * (p2.windN - p1.windN);
     ret.velAircraft = p1.velAircraft + a * (p2.velAircraft - p1.velAircraft);
+    ret.windErr = p1.windErr + a * (p2.windErr - p1.windErr);
 
     return ret;
 }

--- a/src/datapoint.cpp
+++ b/src/datapoint.cpp
@@ -38,5 +38,9 @@ DataPoint DataPoint::interpolate(
 
     ret.curv = p1.curv + a * (p2.curv - p1.curv);
 
+    ret.windE = p1.windE + a * (p2.windE - p1.windE);
+    ret.windN = p1.windN + a * (p2.windN - p1.windN);
+    ret.velAircraft = p1.velAircraft + a * (p2.velAircraft - p1.velAircraft);
+
     return ret;
 }

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -35,6 +35,10 @@ public:
 
     double      curv;
 
+    double      windE;
+    double      windN;
+    double      velAircraft;
+
     static DataPoint interpolate(const DataPoint &p1,
                                  const DataPoint &p2,
                                  double a);
@@ -109,6 +113,21 @@ public:
     static double distance3D(const DataPoint &dp)
     {
         return dp.dist3D;
+    }
+
+    static double windSpeed(const DataPoint &dp)
+    {
+        return sqrt(dp.windE * dp.windE + dp.windN * dp.windN);
+    }
+
+    static double windDirection(const DataPoint &dp)
+    {
+        return atan2(-dp.windE, -dp.windN) / M_PI * 180;
+    }
+
+    static double aircraftSpeed(const DataPoint &dp)
+    {
+        return dp.velAircraft;
     }
 };
 

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -38,6 +38,7 @@ public:
     double      windE;
     double      windN;
     double      velAircraft;
+    double      windErr;
 
     static DataPoint interpolate(const DataPoint &p1,
                                  const DataPoint &p2,
@@ -128,6 +129,11 @@ public:
     static double aircraftSpeed(const DataPoint &dp)
     {
         return dp.velAircraft;
+    }
+
+    static double windError(const DataPoint &dp)
+    {
+        return dp.windErr;
     }
 };
 

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -122,7 +122,7 @@ public:
 
     static double windDirection(const DataPoint &dp)
     {
-        return atan2(-dp.windE, -dp.windN) / M_PI * 180;
+        return fmod(atan2(-dp.windE, -dp.windN) / M_PI * 180 + 360, 360);
     }
 
     static double aircraftSpeed(const DataPoint &dp)

--- a/src/dataview.h
+++ b/src/dataview.h
@@ -35,7 +35,7 @@ private:
 
     QPoint      m_topViewBeginPos;
     bool        m_topViewPan;
-\
+
     void setViewRange(double xMin, double xMax,
                       double yMin, double yMax);
     void addNorthArrow();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -373,6 +373,9 @@ void MainWindow::on_actionImport_triggered()
 void MainWindow::getWind(
         const int center)
 {
+    // Weighted least-squares circle fit based on this:
+    //   http://www.dtcenter.org/met/users/docs/write_ups/circle_fit.pdf
+
     const double dtMax = 30;    // TODO: This should be a preference
 
     DataPoint &dp0 = m_data[center];

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -15,6 +15,7 @@
 #include "dataview.h"
 #include "mapview.h"
 #include "videoview.h"
+#include "windplot.h"
 
 MainWindow::MainWindow(
         QWidget *parent):
@@ -40,6 +41,9 @@ MainWindow::MainWindow(
 
     // Initialize map view
     initMapView();
+
+    // Initialize wind view
+    initWindView();
 
     // Restore window state
     readSettings();
@@ -158,6 +162,27 @@ void MainWindow::initMapView()
             mapView, SLOT(initView()));
     connect(this, SIGNAL(dataChanged()),
             mapView, SLOT(updateView()));
+}
+
+void MainWindow::initWindView()
+{
+    WindPlot *windPlot = new WindPlot;
+    QDockWidget *dockWidget = new QDockWidget(tr("Wind View"));
+    dockWidget->setWidget(windPlot);
+    dockWidget->setObjectName("windView");
+    addDockWidget(Qt::BottomDockWidgetArea, dockWidget);
+
+    windPlot->setMainWindow(this);
+
+    connect(m_ui->actionShowWindView, SIGNAL(toggled(bool)),
+            dockWidget, SLOT(setVisible(bool)));
+    connect(dockWidget, SIGNAL(visibilityChanged(bool)),
+            m_ui->actionShowWindView, SLOT(setChecked(bool)));
+
+    connect(this, SIGNAL(dataLoaded()),
+            windPlot, SLOT(initPlot()));
+    connect(this, SIGNAL(dataChanged()),
+            windPlot, SLOT(updatePlot()));
 }
 
 void MainWindow::closeEvent(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -170,6 +170,7 @@ void MainWindow::initWindView()
     QDockWidget *dockWidget = new QDockWidget(tr("Wind View"));
     dockWidget->setWidget(windPlot);
     dockWidget->setObjectName("windView");
+    dockWidget->setVisible(false);
     addDockWidget(Qt::BottomDockWidgetArea, dockWidget);
 
     windPlot->setMainWindow(this);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -220,25 +220,37 @@ DataPoint MainWindow::interpolateDataT(
 int MainWindow::findIndexBelowT(
         double t)
 {
-    for (int i = 0; i < m_data.size(); ++i)
+    int below = -1;
+    int above = m_data.size();
+
+    while (below + 1 != above)
     {
-        DataPoint &dp = m_data[i];
-        if (dp.t > t) return i - 1;
+        int mid = (below + above) / 2;
+        const DataPoint &dp = m_data[mid];
+
+        if (dp.t < t) below = mid;
+        else          above = mid;
     }
 
-    return m_data.size() - 1;
+    return below;
 }
 
 int MainWindow::findIndexAboveT(
         double t)
 {
-    for (int i = m_data.size() - 1; i >= 0; --i)
+    int below = -1;
+    int above = m_data.size();
+
+    while (below + 1 != above)
     {
-        DataPoint &dp = m_data[i];
-        if (dp.t <= t) return i + 1;
+        int mid = (below + above) / 2;
+        const DataPoint &dp = m_data[mid];
+
+        if (dp.t > t) above = mid;
+        else          below = mid;
     }
 
-    return 0;
+    return above;
 }
 
 void MainWindow::on_actionImport_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -386,16 +386,15 @@ void MainWindow::getWind(
 
     DataPoint &dp0 = m_data[center];
 
+    int start = findIndexBelowT(dp0.t - m_dtWind) + 1;
+    int end   = findIndexAboveT(dp0.t + m_dtWind);
+
     double xbar = 0, ybar = 0, N = 0;
-    for (int i = 0; i < m_data.size(); ++i)
+    for (int i = start; i < end; ++i)
     {
         DataPoint &dp = m_data[i];
 
         const double dt = dp.t - dp0.t;
-
-        if (dt < -m_dtWind) continue;
-        if (dt >  m_dtWind) break;
-
         const double wi = 0.5 * (1 + cos(M_PI * dt / m_dtWind));
 
         const double xi = dp.velE;
@@ -420,15 +419,11 @@ void MainWindow::getWind(
 
     double suu = 0, suv = 0, svv = 0;
     double suuu = 0, suvv = 0, svuu = 0, svvv = 0;
-    for (int i = 0; i < m_data.size(); ++i)
+    for (int i = start; i < end; ++i)
     {
         DataPoint &dp = m_data[i];
 
         const double dt = dp.t - dp0.t;
-
-        if (dt < -m_dtWind) continue;
-        if (dt >  m_dtWind) break;
-
         const double wi = 0.5 * (1 + cos(M_PI * dt / m_dtWind));
 
         const double xi = dp.velE;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -388,7 +388,6 @@ void MainWindow::getWind(
         if (dt >  dtMax) break;
 
         const double wi = 0.5 * (1 + cos(M_PI * dt / dtMax));
-        // const double wi = 1;
 
         const double xi = dp.velE;
         const double yi = dp.velN;
@@ -422,7 +421,6 @@ void MainWindow::getWind(
         if (dt >  dtMax) break;
 
         const double wi = 0.5 * (1 + cos(M_PI * dt / dtMax));
-        // const double wi = 1;
 
         const double xi = dp.velE;
         const double yi = dp.velN;
@@ -451,7 +449,7 @@ void MainWindow::getWind(
     }
 
     const double uc = 1 / det * (0.5 * svv * (suuu + suvv) - 0.5 * suv * (svvv + svuu));
-    const double vc = 1 / det * (0.5 * suu * (suuu + suvv) - 0.5 * suv * (svvv + svuu));
+    const double vc = 1 / det * (0.5 * suu * (svvv + svuu) - 0.5 * suv * (suuu + suvv));
 
     const double xc = uc + xbar;
     const double yc = vc + ybar;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -411,6 +411,7 @@ void MainWindow::getWind(
         dp0.windE = 0;
         dp0.windN = 0;
         dp0.velAircraft = 0;
+        dp0.windErr = 0;
         return;
     }
 
@@ -449,6 +450,7 @@ void MainWindow::getWind(
         dp0.windE = 0;
         dp0.windN = 0;
         dp0.velAircraft = 0;
+        dp0.windErr = 0;
         return;
     }
 
@@ -464,6 +466,26 @@ void MainWindow::getWind(
     dp0.windE = xc;
     dp0.windN = yc;
     dp0.velAircraft = R;
+
+    double err = 0;
+    for (int i = start; i < end; ++i)
+    {
+        DataPoint &dp = m_data[i];
+
+        const double dt = dp.t - dp0.t;
+        const double wi = 0.5 * (1 + cos(M_PI * dt / m_dtWind));
+
+        const double xi = dp.velE;
+        const double yi = dp.velN;
+
+        const double dx = xi - xc;
+        const double dy = yi - yc;
+
+        const double term = sqrt(dx * dx + dy * dy) - R;
+        err += wi * term * term;
+    }
+
+    dp0.windErr = sqrt(err / N);
 }
 
 double MainWindow::getSlope(
@@ -661,6 +683,7 @@ void MainWindow::updateLeftActions()
     m_ui->actionWindSpeed->setChecked(m_ui->plotArea->plotVisible(DataPlot::WindSpeed));
     m_ui->actionWindDirection->setChecked(m_ui->plotArea->plotVisible(DataPlot::WindDirection));
     m_ui->actionAircraftSpeed->setChecked(m_ui->plotArea->plotVisible(DataPlot::AircraftSpeed));
+    m_ui->actionWindError->setChecked(m_ui->plotArea->plotVisible(DataPlot::WindError));
 }
 
 void MainWindow::on_actionTotalSpeed_triggered()
@@ -716,6 +739,11 @@ void MainWindow::on_actionWindDirection_triggered()
 void MainWindow::on_actionAircraftSpeed_triggered()
 {
     m_ui->plotArea->togglePlot(DataPlot::AircraftSpeed);
+}
+
+void MainWindow::on_actionWindError_triggered()
+{
+    m_ui->plotArea->togglePlot(DataPlot::WindError);
 }
 
 void MainWindow::on_actionPan_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -63,6 +63,9 @@ public:
 
     DataPoint interpolateDataT(double t);
 
+    int findIndexBelowT(double t);
+    int findIndexAboveT(double t);
+
 protected:
     void closeEvent(QCloseEvent *event);
 
@@ -141,9 +144,6 @@ private:
     double getSlope(const int center, double (*value)(const DataPoint &)) const;
 
     void initRange();
-
-    int findIndexBelowT(double t);
-    int findIndexAboveT(double t);
 
     void updateBottomActions();
     void updateLeftActions();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -79,6 +79,9 @@ private slots:
     void on_actionVerticalAccuracy_triggered();
     void on_actionSpeedAccuracy_triggered();
     void on_actionNumberOfSatellites_triggered();
+    void on_actionWindSpeed_triggered();
+    void on_actionWindDirection_triggered();
+    void on_actionAircraftSpeed_triggered();
 
     void on_actionPan_triggered();
     void on_actionZoom_triggered();
@@ -128,6 +131,7 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
+    void getWind(const int center);
     double getSlope(const int center, double (*value)(const DataPoint &)) const;
 
     void initRange();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -32,6 +32,7 @@ public:
     const DataPoint &dataPoint(int i) const { return m_data[i]; }
 
     PlotValue::Units units() const { return m_units; }
+    double dtWind() const { return m_dtWind; }
 
     void setRange(double lower, double upper);
     double rangeLower() const { return mRangeLower; }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -130,6 +130,7 @@ private:
     void initPlot();
     void initViews();
     void initMapView();
+    void initWindView();
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -111,6 +111,7 @@ private:
     double                m_viewDataRotation;
 
     PlotValue::Units      m_units;
+    double                m_dtWind;
 
     QVector< DataPoint >  m_waypoints;
 
@@ -131,7 +132,9 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
+    void initWind();
     void getWind(const int center);
+
     double getSlope(const int center, double (*value)(const DataPoint &)) const;
 
     void initRange();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -82,6 +82,7 @@ private slots:
     void on_actionWindSpeed_triggered();
     void on_actionWindDirection_triggered();
     void on_actionAircraftSpeed_triggered();
+    void on_actionWindError_triggered();
 
     void on_actionPan_triggered();
     void on_actionZoom_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -79,7 +79,6 @@
     <addaction name="actionWindSpeed"/>
     <addaction name="actionWindDirection"/>
     <addaction name="actionAircraftSpeed"/>
-    <addaction name="actionWindError"/>
    </widget>
    <widget class="QMenu" name="menuDomain">
     <property name="title">

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -75,6 +75,10 @@
     <addaction name="actionSpeedAccuracy"/>
     <addaction name="separator"/>
     <addaction name="actionNumberOfSatellites"/>
+    <addaction name="separator"/>
+    <addaction name="actionWindSpeed"/>
+    <addaction name="actionWindDirection"/>
+    <addaction name="actionAircraftSpeed"/>
    </widget>
    <widget class="QMenu" name="menuDomain">
     <property name="title">
@@ -427,6 +431,39 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+L</string>
+   </property>
+  </action>
+  <action name="actionWindSpeed">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Wind Speed</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+W</string>
+   </property>
+  </action>
+  <action name="actionWindDirection">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Wind Direction</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+D</string>
+   </property>
+  </action>
+  <action name="actionAircraftSpeed">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Aircraft Speed</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+A</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -79,6 +79,7 @@
     <addaction name="actionWindSpeed"/>
     <addaction name="actionWindDirection"/>
     <addaction name="actionAircraftSpeed"/>
+    <addaction name="actionWindError"/>
    </widget>
    <widget class="QMenu" name="menuDomain">
     <property name="title">
@@ -464,6 +465,17 @@
    </property>
    <property name="shortcut">
     <string>Shift+A</string>
+   </property>
+  </action>
+  <action name="actionWindError">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Wind Error</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+E</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -108,6 +108,7 @@
     <addaction name="actionShowTopView"/>
     <addaction name="actionShowFrontView"/>
     <addaction name="actionShowMapView"/>
+    <addaction name="actionShowWindView"/>
    </widget>
    <addaction name="menu_File"/>
    <addaction name="menuPlots"/>
@@ -476,6 +477,17 @@
    </property>
    <property name="shortcut">
     <string>Shift+E</string>
+   </property>
+  </action>
+  <action name="actionShowWindView">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Wind View</string>
+   </property>
+   <property name="shortcut">
+    <string>Alt+5</string>
    </property>
   </action>
  </widget>

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -335,4 +335,61 @@ public:
     }
 };
 
+class PlotWindSpeed: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotWindSpeed() {}
+    const QString title(Units units) const
+    {
+        if (units == Metric) return tr("Wind Speed (km/h)");
+        else                 return tr("Wind Speed (mph)");
+    }
+    const QColor color() const { return Qt::darkGray; }
+    double value(const DataPoint &dp, Units units) const
+    {
+        if (units == Metric) return DataPoint::windSpeed(dp) * MPS_TO_KMH;
+        else                 return DataPoint::windSpeed(dp) * MPS_TO_MPH;
+    }
+};
+
+class PlotWindDirection: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotWindDirection() {}
+    const QString title(Units units) const
+    {
+        Q_UNUSED(units);
+        return tr("Wind Direction (deg)");
+    }
+    const QColor color() const { return Qt::lightGray; }
+    double value(const DataPoint &dp, Units units) const
+    {
+        Q_UNUSED(units);
+        return DataPoint::windDirection(dp);
+    }
+};
+
+class PlotAircraftSpeed: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotAircraftSpeed() {}
+    const QString title(Units units) const
+    {
+        if (units == Metric) return tr("Aircraft Speed (km/h)");
+        else                 return tr("Aircraft Speed (mph)");
+    }
+    const QColor color() const { return Qt::gray; }
+    double value(const DataPoint &dp, Units units) const
+    {
+        if (units == Metric) return DataPoint::aircraftSpeed(dp) * MPS_TO_KMH;
+        else                 return DataPoint::aircraftSpeed(dp) * MPS_TO_MPH;
+    }
+};
+
 #endif // PLOTVALUE_H

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -346,7 +346,7 @@ public:
         if (units == Metric) return tr("Wind Speed (km/h)");
         else                 return tr("Wind Speed (mph)");
     }
-    const QColor color() const { return Qt::darkGray; }
+    const QColor color() const { return Qt::darkRed; }
     double value(const DataPoint &dp, Units units) const
     {
         if (units == Metric) return DataPoint::windSpeed(dp) * MPS_TO_KMH;
@@ -365,7 +365,7 @@ public:
         Q_UNUSED(units);
         return tr("Wind Direction (deg)");
     }
-    const QColor color() const { return Qt::lightGray; }
+    const QColor color() const { return Qt::darkGreen; }
     double value(const DataPoint &dp, Units units) const
     {
         Q_UNUSED(units);
@@ -384,7 +384,7 @@ public:
         if (units == Metric) return tr("Aircraft Speed (km/h)");
         else                 return tr("Aircraft Speed (mph)");
     }
-    const QColor color() const { return Qt::gray; }
+    const QColor color() const { return Qt::darkBlue; }
     double value(const DataPoint &dp, Units units) const
     {
         if (units == Metric) return DataPoint::aircraftSpeed(dp) * MPS_TO_KMH;

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -392,4 +392,23 @@ public:
     }
 };
 
+class PlotWindError: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotWindError() {}
+    const QString title(Units units) const
+    {
+        if (units == Metric) return tr("Wind Error (km/h)");
+        else                 return tr("Wind Error (mph)");
+    }
+    const QColor color() const { return Qt::lightGray; }
+    double value(const DataPoint &dp, Units units) const
+    {
+        if (units == Metric) return DataPoint::windError(dp) * MPS_TO_KMH;
+        else                 return DataPoint::windError(dp) * MPS_TO_MPH;
+    }
+};
+
 #endif // PLOTVALUE_H

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -1,0 +1,56 @@
+#include <QToolTip>
+
+#include "windplot.h"
+#include "mainwindow.h"
+
+WindPlot::WindPlot(QWidget *parent) :
+    QCustomPlot(parent),
+    mMainWindow(0)
+{
+
+}
+
+QSize WindPlot::sizeHint() const
+{
+    // Keeps windows from being intialized as very short
+    return QSize(175, 175);
+}
+
+void WindPlot::updatePlot()
+{
+
+}
+
+void WindPlot::setViewRange(
+        double xMin,
+        double xMax,
+        double yMin,
+        double yMax)
+{
+    QPainter painter(this);
+
+    double xMMperPix = (double) painter.device()->widthMM() / painter.device()->width();
+    double yMMperPix = (double) painter.device()->heightMM() / painter.device()->height();
+
+    QRect rect = axisRect()->rect();
+
+    double xSpan = (xMax - xMin) * 1.2;
+    double ySpan = (yMax - yMin) * 1.2;
+
+    double xScale = xSpan / rect.width() / xMMperPix;
+    double yScale = ySpan / rect.height() / yMMperPix;
+
+    double scale = qMax(xScale, yScale);
+
+    double xMid = (xMin + xMax) / 2;
+    double yMid = (yMin + yMax) / 2;
+
+    xMin = xMid - rect.width() * xMMperPix * scale / 2;
+    xMax = xMid + rect.width() * xMMperPix * scale / 2;
+
+    yMin = yMid - rect.height() * yMMperPix * scale / 2;
+    yMax = yMid + rect.height() * yMMperPix * scale / 2;
+
+    xAxis->setRange(xMin, xMax);
+    yAxis->setRange(yMin, yMax);
+}

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -82,6 +82,11 @@ void WindPlot::setMark(
             .arg(PlotWindDirection().value(dp, mMainWindow->units()))
             .arg(PlotWindDirection().color().name());
 
+    status += QString("<tr style='color:%3;'><td>%1</td><td>%2</td></tr>")
+            .arg(PlotAircraftSpeed().title(mMainWindow->units()))
+            .arg(PlotAircraftSpeed().value(dp, mMainWindow->units()))
+            .arg(PlotAircraftSpeed().color().name());
+
     status += QString("</table>");
 
     QToolTip::showText(QCursor::pos(), status);

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -72,41 +72,41 @@ void WindPlot::updatePlot()
     double xMin, xMax;
     double yMin, yMax;
 
+    int start = mMainWindow->findIndexBelowT(lower) + 1;
+    int end   = mMainWindow->findIndexAboveT(upper);
+
     bool first = true;
-    for (int i = 0; i < mMainWindow->dataSize(); ++i)
+    for (int i = start; i < end; ++i)
     {
         const DataPoint &dp = mMainWindow->dataPoint(i);
 
-        if (lower <= dp.t && dp.t <= upper)
+        t.append(dp.t);
+
+        if (mMainWindow->units() == PlotValue::Metric)
         {
-            t.append(dp.t);
+            x.append(dp.velE * MPS_TO_KMH);
+            y.append(dp.velN * MPS_TO_KMH);
+        }
+        else
+        {
+            x.append(dp.velE * MPS_TO_MPH);
+            y.append(dp.velN * MPS_TO_MPH);
+        }
 
-            if (mMainWindow->units() == PlotValue::Metric)
-            {
-                x.append(dp.velE * MPS_TO_KMH);
-                y.append(dp.velN * MPS_TO_KMH);
-            }
-            else
-            {
-                x.append(dp.velE * MPS_TO_MPH);
-                y.append(dp.velN * MPS_TO_MPH);
-            }
+        if (first)
+        {
+            xMin = xMax = x.back();
+            yMin = yMax = y.back();
 
-            if (first)
-            {
-                xMin = xMax = x.back();
-                yMin = yMax = y.back();
+            first = false;
+        }
+        else
+        {
+            if (x.back() < xMin) xMin = x.back();
+            if (x.back() > xMax) xMax = x.back();
 
-                first = false;
-            }
-            else
-            {
-                if (x.back() < xMin) xMin = x.back();
-                if (x.back() > xMax) xMax = x.back();
-
-                if (y.back() < yMin) yMin = y.back();
-                if (y.back() > yMax) yMax = y.back();
-            }
+            if (y.back() < yMin) yMin = y.back();
+            if (y.back() > yMax) yMax = y.back();
         }
     }
 
@@ -125,24 +125,24 @@ void WindPlot::updatePlot()
         x.clear();
         y.clear();
 
-        for (int i = 0; i < mMainWindow->dataSize(); ++i)
+        int start = mMainWindow->findIndexBelowT(dpEnd.t - mMainWindow->dtWind()) + 1;
+        int end   = mMainWindow->findIndexAboveT(dpEnd.t + mMainWindow->dtWind());
+
+        for (int i = start; i <= end; ++i)
         {
             const DataPoint &dp = mMainWindow->dataPoint(i);
 
-            if (dpEnd.t - mMainWindow->dtWind() <= dp.t && dp.t <= dpEnd.t + mMainWindow->dtWind())
-            {
-                t.append(dp.t);
+            t.append(dp.t);
 
-                if (mMainWindow->units() == PlotValue::Metric)
-                {
-                    x.append(dp.velE * MPS_TO_KMH);
-                    y.append(dp.velN * MPS_TO_KMH);
-                }
-                else
-                {
-                    x.append(dp.velE * MPS_TO_MPH);
-                    y.append(dp.velN * MPS_TO_MPH);
-                }
+            if (mMainWindow->units() == PlotValue::Metric)
+            {
+                x.append(dp.velE * MPS_TO_KMH);
+                y.append(dp.velN * MPS_TO_KMH);
+            }
+            else
+            {
+                x.append(dp.velE * MPS_TO_MPH);
+                y.append(dp.velN * MPS_TO_MPH);
             }
         }
 

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -141,6 +141,36 @@ void WindPlot::updatePlot()
         graph->setPen(QPen(Qt::black));
         graph->setLineStyle(QCPGraph::lsNone);
         graph->setScatterStyle(QCPScatterStyle::ssDisc);
+
+        const double x0 = dpEnd.windE;
+        const double y0 = dpEnd.windN;
+        const double r = dpEnd.velAircraft;
+
+        QVector< double > tCircle, xCircle, yCircle;
+
+        for (int i = 0; i <= 100; ++i)
+        {
+            tCircle.append(i);
+
+            const double x = x0 + r * cos((double) i / 100 * 2 * M_PI);
+            const double y = y0 + r * sin((double) i / 100 * 2 * M_PI);
+
+            if (mMainWindow->units() == PlotValue::Metric)
+            {
+                xCircle.append(x * MPS_TO_KMH);
+                yCircle.append(y * MPS_TO_KMH);
+            }
+            else
+            {
+                xCircle.append(x * MPS_TO_MPH);
+                yCircle.append(y * MPS_TO_MPH);
+            }
+        }
+
+        curve = new QCPCurve(xAxis, yAxis);
+        curve->setData(tCircle, xCircle, yCircle);
+        curve->setPen(QPen(Qt::red));
+        addPlottable(curve);
     }
 
     replot();

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -62,6 +62,8 @@ void WindPlot::mouseMoveEvent(
 
 void WindPlot::updatePlot()
 {
+    clearPlottables();
+
     double lower = mMainWindow->rangeLower();
     double upper = mMainWindow->rangeUpper();
 
@@ -71,7 +73,6 @@ void WindPlot::updatePlot()
     double yMin, yMax;
 
     bool first = true;
-
     for (int i = 0; i < mMainWindow->dataSize(); ++i)
     {
         const DataPoint &dp = mMainWindow->dataPoint(i);
@@ -109,12 +110,9 @@ void WindPlot::updatePlot()
         }
     }
 
-    clearPlottables();
-
     QCPCurve *curve = new QCPCurve(xAxis, yAxis);
     curve->setData(t, x, y);
-    curve->setPen(QPen(Qt::black));
-
+    curve->setPen(QPen(Qt::lightGray));
     addPlottable(curve);
 
     setViewRange(xMin, xMax, yMin, yMax);
@@ -122,6 +120,36 @@ void WindPlot::updatePlot()
     if (mMainWindow->markActive())
     {
         const DataPoint &dpEnd = mMainWindow->interpolateDataT(mMainWindow->markEnd());
+
+        t.clear();
+        x.clear();
+        y.clear();
+
+        for (int i = 0; i < mMainWindow->dataSize(); ++i)
+        {
+            const DataPoint &dp = mMainWindow->dataPoint(i);
+
+            if (dpEnd.t - mMainWindow->dtWind() <= dp.t && dp.t <= dpEnd.t + mMainWindow->dtWind())
+            {
+                t.append(dp.t);
+
+                if (mMainWindow->units() == PlotValue::Metric)
+                {
+                    x.append(dp.velE * MPS_TO_KMH);
+                    y.append(dp.velN * MPS_TO_KMH);
+                }
+                else
+                {
+                    x.append(dp.velE * MPS_TO_MPH);
+                    y.append(dp.velN * MPS_TO_MPH);
+                }
+            }
+        }
+
+        curve = new QCPCurve(xAxis, yAxis);
+        curve->setData(t, x, y);
+        curve->setPen(QPen(Qt::black));
+        addPlottable(curve);
 
         QVector< double > xMark, yMark;
 

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -1,5 +1,6 @@
 #include <QToolTip>
 
+#include "common.h"
 #include "windplot.h"
 #include "mainwindow.h"
 
@@ -16,9 +17,133 @@ QSize WindPlot::sizeHint() const
     return QSize(175, 175);
 }
 
+void WindPlot::mouseMoveEvent(
+        QMouseEvent *event)
+{
+    if (QCPCurve *curve = qobject_cast<QCPCurve *>(plottable(0)))
+    {
+        const QCPCurveDataMap *data = curve->data();
+
+        double resultTime;
+        double resultDistance = std::numeric_limits<double>::max();
+
+        for (QCPCurveDataMap::const_iterator it = data->constBegin();
+             it != data->constEnd() && (it + 1) != data->constEnd();
+             ++ it)
+        {
+            QPointF pt1 = QPointF(xAxis->coordToPixel(it.value().key),
+                                  yAxis->coordToPixel(it.value().value));
+            QPointF pt2 = QPointF(xAxis->coordToPixel((it + 1).value().key),
+                                  yAxis->coordToPixel((it + 1).value().value));
+
+            double mu;
+            double dist = sqrt(distSqrToLine(pt1, pt2, event->pos(), mu));
+
+            if (dist < resultDistance)
+            {
+                double t1 = it.value().t;
+                double t2 = (it + 1).value().t;
+
+                resultTime = t1 + mu * (t2 - t1);
+                resultDistance = dist;
+            }
+        }
+
+        if (resultDistance < selectionTolerance())
+        {
+            mMainWindow->setMark(resultTime);
+        }
+        else
+        {
+            mMainWindow->clearMark();
+        }
+    }
+}
+
 void WindPlot::updatePlot()
 {
+    double lower = mMainWindow->rangeLower();
+    double upper = mMainWindow->rangeUpper();
 
+    QVector< double > t, x, y;
+
+    double xMin, xMax;
+    double yMin, yMax;
+
+    bool first = true;
+
+    for (int i = 0; i < mMainWindow->dataSize(); ++i)
+    {
+        const DataPoint &dp = mMainWindow->dataPoint(i);
+
+        if (lower <= dp.t && dp.t <= upper)
+        {
+            t.append(dp.t);
+
+            if (mMainWindow->units() == PlotValue::Metric)
+            {
+                x.append(dp.velE * MPS_TO_KMH);
+                y.append(dp.velN * MPS_TO_KMH);
+            }
+            else
+            {
+                x.append(dp.velE * MPS_TO_MPH);
+                y.append(dp.velN * MPS_TO_MPH);
+            }
+
+            if (first)
+            {
+                xMin = xMax = x.back();
+                yMin = yMax = y.back();
+
+                first = false;
+            }
+            else
+            {
+                if (x.back() < xMin) xMin = x.back();
+                if (x.back() > xMax) xMax = x.back();
+
+                if (y.back() < yMin) yMin = y.back();
+                if (y.back() > yMax) yMax = y.back();
+            }
+        }
+    }
+
+    clearPlottables();
+
+    QCPCurve *curve = new QCPCurve(xAxis, yAxis);
+    curve->setData(t, x, y);
+    curve->setPen(QPen(Qt::black));
+
+    addPlottable(curve);
+
+    setViewRange(xMin, xMax, yMin, yMax);
+
+    if (mMainWindow->markActive())
+    {
+        const DataPoint &dpEnd = mMainWindow->interpolateDataT(mMainWindow->markEnd());
+
+        QVector< double > xMark, yMark;
+
+        if (mMainWindow->units() == PlotValue::Metric)
+        {
+            xMark.append(dpEnd.velE * MPS_TO_KMH);
+            yMark.append(dpEnd.velN * MPS_TO_KMH);
+        }
+        else
+        {
+            xMark.append(dpEnd.velE * MPS_TO_MPH);
+            yMark.append(dpEnd.velN * MPS_TO_MPH);
+        }
+
+        QCPGraph *graph = addGraph();
+        graph->setData(xMark, yMark);
+        graph->setPen(QPen(Qt::black));
+        graph->setLineStyle(QCPGraph::lsNone);
+        graph->setScatterStyle(QCPScatterStyle::ssDisc);
+    }
+
+    replot();
 }
 
 void WindPlot::setViewRange(

--- a/src/windplot.cpp
+++ b/src/windplot.cpp
@@ -51,13 +51,40 @@ void WindPlot::mouseMoveEvent(
 
         if (resultDistance < selectionTolerance())
         {
-            mMainWindow->setMark(resultTime);
+            setMark(resultTime);
         }
         else
         {
             mMainWindow->clearMark();
+            QToolTip::hideText();
         }
     }
+}
+
+void WindPlot::setMark(
+        double mark)
+{
+    if (mMainWindow->dataSize() == 0) return;
+
+    DataPoint dp = mMainWindow->interpolateDataT(mark);
+    mMainWindow->setMark(mark);
+
+    QString status;
+    status = QString("<table width='200'>");
+
+    status += QString("<tr style='color:%3;'><td>%1</td><td>%2</td></tr>")
+            .arg(PlotWindSpeed().title(mMainWindow->units()))
+            .arg(PlotWindSpeed().value(dp, mMainWindow->units()))
+            .arg(PlotWindSpeed().color().name());
+
+    status += QString("<tr style='color:%3;'><td>%1</td><td>%2</td></tr>")
+            .arg(PlotWindDirection().title(mMainWindow->units()))
+            .arg(PlotWindDirection().value(dp, mMainWindow->units()))
+            .arg(PlotWindDirection().color().name());
+
+    status += QString("</table>");
+
+    QToolTip::showText(QCursor::pos(), status);
 }
 
 void WindPlot::updatePlot()
@@ -167,6 +194,26 @@ void WindPlot::updatePlot()
         QCPGraph *graph = addGraph();
         graph->setData(xMark, yMark);
         graph->setPen(QPen(Qt::black));
+        graph->setLineStyle(QCPGraph::lsNone);
+        graph->setScatterStyle(QCPScatterStyle::ssDisc);
+
+        xMark.clear();
+        yMark.clear();
+
+        if (mMainWindow->units() == PlotValue::Metric)
+        {
+            xMark.append(dpEnd.windE * MPS_TO_KMH);
+            yMark.append(dpEnd.windN * MPS_TO_KMH);
+        }
+        else
+        {
+            xMark.append(dpEnd.windE * MPS_TO_MPH);
+            yMark.append(dpEnd.windN * MPS_TO_MPH);
+        }
+
+        graph = addGraph();
+        graph->setData(xMark, yMark);
+        graph->setPen(QPen(Qt::red));
         graph->setLineStyle(QCPGraph::lsNone);
         graph->setScatterStyle(QCPScatterStyle::ssDisc);
 

--- a/src/windplot.h
+++ b/src/windplot.h
@@ -16,6 +16,9 @@ public:
 
     void setMainWindow(MainWindow *mainWindow) { mMainWindow = mainWindow; }
 
+protected:
+    void mouseMoveEvent(QMouseEvent *event);
+
 private:
     MainWindow *mMainWindow;
 

--- a/src/windplot.h
+++ b/src/windplot.h
@@ -22,6 +22,7 @@ protected:
 private:
     MainWindow *mMainWindow;
 
+    void setMark(double mark);
     void setViewRange(double xMin, double xMax,
                       double yMin, double yMax);
 

--- a/src/windplot.h
+++ b/src/windplot.h
@@ -1,0 +1,29 @@
+#ifndef WINDPLOT_H
+#define WINDPLOT_H
+
+#include "qcustomplot.h"
+
+class MainWindow;
+
+class WindPlot : public QCustomPlot
+{
+    Q_OBJECT
+
+public:
+    explicit WindPlot(QWidget *parent = 0);
+
+    virtual QSize sizeHint() const;
+
+    void setMainWindow(MainWindow *mainWindow) { mMainWindow = mainWindow; }
+
+private:
+    MainWindow *mMainWindow;
+
+    void setViewRange(double xMin, double xMax,
+                      double yMin, double yMax);
+
+public slots:
+    void updatePlot();
+};
+
+#endif // WINDPLOT_H


### PR DESCRIPTION
Added tools to estimate winds using data from the climb to altitude.

To use these tools, have the pilot perform a turn with constant indicated airspeed. The turn need not be a full 360 degrees or a constant turn rate.

The viewer estimates winds by performing a weighted least-squares fit to a window surrounding each data point. The size of the window can be specified in preferences, but defaults to 30 seconds each way.

The data can be viewed as three additional plots in the plot view (wind speed, wind direction and aircraft speed) or by showing the "wind view". In this view, the velocity data is shown along with the results of the least-squares fit. By moving the mouse in the wind view, the user can explore the wind data to determine the best fit.