### PR TITLE
Add course and course accuracy

### DIFF
--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -70,6 +70,8 @@ void DataPlot::initPlot()
     m_yValues.append(new PlotEnergyRate);
     m_yValues.append(new PlotLift);
     m_yValues.append(new PlotDrag);
+    m_yValues.append(new PlotCourse);
+    m_yValues.append(new PlotCourseAccuracy);
 
     foreach (PlotValue *v, m_yValues)
     {

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -35,6 +35,8 @@ public:
         EnergyRate,
         Lift,
         Drag,
+        Course,
+        CourseAccuracy,
         yaLast
     } YAxisType;
 

--- a/src/datapoint.cpp
+++ b/src/datapoint.cpp
@@ -44,5 +44,8 @@ DataPoint DataPoint::interpolate(
     ret.lift = p1.lift + a * (p2.lift - p1.lift);
     ret.drag = p1.drag + a * (p2.drag - p1.drag);
 
+    ret.heading = p1.heading + a * (p2.heading - p1.heading);
+    ret.cAcc = p1.cAcc + a * (p2.cAcc - p1.cAcc);
+
     return ret;
 }

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -26,6 +26,9 @@ public:
     double      vAcc;
     double      sAcc;
 
+    double      heading;
+    double      cAcc;
+
     int         numSV;
 
     double      t;
@@ -153,6 +156,16 @@ public:
     static double dragCoefficient(const DataPoint &dp)
     {
         return dp.drag;
+    }
+
+    static double course(const DataPoint &dp)
+    {
+        return dp.heading;
+    }
+
+    static double courseAccuracy(const DataPoint &dp)
+    {
+        return dp.cAcc;
     }
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -451,6 +451,10 @@ void MainWindow::on_actionImport_triggered()
     // Flags for what data is available
     const bool hasHeading = colMap.contains(Heading) && colMap.contains(CAcc);
 
+    // Cumulative heading
+    double prevHeading;
+    bool firstHeading = true;
+
     // Skip next row
     if (!in.atEnd()) in.readLine();
 
@@ -488,14 +492,22 @@ void MainWindow::on_actionImport_triggered()
         {
             // Calculate heading
             pt.heading = atan2(pt.velE, pt.velN) / PI * 180;
-            while (pt.heading < -180) pt.heading += 360;
-            while (pt.heading >  180) pt.heading -= 360;
 
             // Calculate heading accuracy
             const double s = DataPoint::totalSpeed(pt);
             if (s != 0) pt.cAcc = pt.sAcc / s;
             else        pt.cAcc = 0;
         }
+
+        // Adjust heading
+        if (!firstHeading)
+        {
+            while (pt.heading <  prevHeading - 180) pt.heading += 360;
+            while (pt.heading >= prevHeading + 180) pt.heading -= 360;
+        }
+
+        firstHeading = false;
+        prevHeading = pt.heading;
 
         pt.numSV = cols[colMap[NumSV]].toDouble();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -828,6 +828,8 @@ void MainWindow::updateLeftActions()
     m_ui->actionEnergyRate->setChecked(m_ui->plotArea->plotVisible(DataPlot::EnergyRate));
     m_ui->actionLift->setChecked(m_ui->plotArea->plotVisible(DataPlot::Lift));
     m_ui->actionDrag->setChecked(m_ui->plotArea->plotVisible(DataPlot::Drag));
+    m_ui->actionCourse->setChecked(m_ui->plotArea->plotVisible(DataPlot::Course));
+    m_ui->actionCourseAccuracy->setChecked(m_ui->plotArea->plotVisible(DataPlot::CourseAccuracy));
 }
 
 void MainWindow::on_actionTotalSpeed_triggered()
@@ -893,6 +895,16 @@ void MainWindow::on_actionLift_triggered()
 void MainWindow::on_actionDrag_triggered()
 {
     m_ui->plotArea->togglePlot(DataPlot::Drag);
+}
+
+void MainWindow::on_actionCourse_triggered()
+{
+    m_ui->plotArea->togglePlot(DataPlot::Course);
+}
+
+void MainWindow::on_actionCourseAccuracy_triggered()
+{
+    m_ui->plotArea->togglePlot(DataPlot::CourseAccuracy);
 }
 
 void MainWindow::on_actionPan_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -136,6 +136,8 @@ private slots:
     void on_actionEnergyRate_triggered();
     void on_actionLift_triggered();
     void on_actionDrag_triggered();
+    void on_actionCourse_triggered();
+    void on_actionCourseAccuracy_triggered();
 
     void on_actionPan_triggered();
     void on_actionZoom_triggered();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -67,6 +67,9 @@
     <addaction name="actionVerticalSpeed"/>
     <addaction name="actionTotalSpeed"/>
     <addaction name="separator"/>
+    <addaction name="actionCourse"/>
+    <addaction name="actionCourseAccuracy"/>
+    <addaction name="separator"/>
     <addaction name="actionGlideRatio"/>
     <addaction name="actionDiveAngle"/>
     <addaction name="actionCurvature"/>
@@ -464,7 +467,7 @@
     <string>Acceleration</string>
    </property>
    <property name="shortcut">
-    <string>Shift+C</string>
+    <string>Shift+A</string>
    </property>
   </action>
   <action name="actionTotalEnergy">
@@ -572,6 +575,28 @@
    </property>
    <property name="shortcut">
     <string>Alt+0</string>
+   </property>
+  </action>
+  <action name="actionCourse">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Course</string>
+   </property>
+   <property name="shortcut">
+    <string>C</string>
+   </property>
+  </action>
+  <action name="actionCourseAccuracy">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Course Accuracy</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+C</string>
    </property>
   </action>
  </widget>

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -592,7 +592,7 @@ class PlotCourse: public PlotValue
     Q_OBJECT
 
 public:
-    PlotCourse(): PlotValue(false, Qt::yellow) {}
+    PlotCourse(): PlotValue(false, Qt::cyan) {}
     const QString title() const
     {
         return tr("Course");
@@ -615,7 +615,7 @@ class PlotCourseAccuracy: public PlotValue
     Q_OBJECT
 
 public:
-    PlotCourseAccuracy(): PlotValue(false, Qt::darkYellow) {}
+    PlotCourseAccuracy(): PlotValue(false, Qt::darkCyan) {}
     const QString title() const
     {
         return tr("Course Accuracy");

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -587,4 +587,50 @@ public:
     bool hasOptimal() const { return true; }
 };
 
+class PlotCourse: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotCourse(): PlotValue(false, Qt::yellow) {}
+    const QString title() const
+    {
+        return tr("Course");
+    }
+    const QString title(Units units) const
+    {
+        Q_UNUSED(units);
+        return title() + tr(" (deg)");
+    }
+    double rawValue(const DataPoint &dp) const
+    {
+        return DataPoint::course(dp);
+    }
+
+    bool hasOptimal() const { return false; }
+};
+
+class PlotCourseAccuracy: public PlotValue
+{
+    Q_OBJECT
+
+public:
+    PlotCourseAccuracy(): PlotValue(false, Qt::darkYellow) {}
+    const QString title() const
+    {
+        return tr("Course Accuracy");
+    }
+    const QString title(Units units) const
+    {
+        Q_UNUSED(units);
+        return title() + tr(" (deg)");
+    }
+    double rawValue(const DataPoint &dp) const
+    {
+        return DataPoint::courseAccuracy(dp);
+    }
+
+    bool hasOptimal() const { return false; }
+};
+
 #endif // PLOTVALUE_H


### PR DESCRIPTION
Added plots for course and course accuracy. If the information is available in the CSV file then it is pulled from there. Otherwise, it is calculated from speed and speed accuracy. Course is "accumulated" so that simple math (e.g., taking the difference between course at two points) gives a more intuitively correct result--i.e., it tells us the total angle turned from one point to the next.