### PR TITLE
Export course between 0 and 360 degrees

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1321,8 +1321,14 @@ void MainWindow::on_actionExportTrack_triggered()
                 stream << QString::number(dp.vAcc, 'f', 3) << ",";
                 stream << QString::number(dp.sAcc, 'f', 2) << ",";
 
-                stream << ",";  // heading
-                stream << ",";  // cAcc
+                // Get adjusted heading
+                double heading = dp.heading;
+                while (heading <  0)   heading += 360;
+                while (heading >= 360) heading -= 360;
+
+                stream << QString::number(heading, 'f', 5) << ",";
+                stream << QString::number(dp.cAcc, 'f', 5) << ",";
+
                 stream << ",";  // gpsFix
 
                 stream << QString::number(dp.numSV) << endl;


### PR DESCRIPTION
Export course data when we export a track. The heading is re-adjusted so that it is between 0 and 360 degrees in the exported file.