### PR TITLE
Allow fixed ground reference for scoring

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -147,6 +147,30 @@ PlotValue::Units ConfigDialog::units() const
     return (PlotValue::Units) ui->unitsCombo->currentIndex();
 }
 
+void ConfigDialog::setGroundReference(
+        MainWindow::GroundReference ref)
+{
+    ui->autoReferenceButton->setChecked(ref == MainWindow::Automatic);
+    ui->fixedReferenceButton->setChecked(ref == MainWindow::Fixed);
+}
+
+double ConfigDialog::fixedReference() const
+{
+    return ui->fixedReferenceEdit->text().toDouble();
+}
+
+void ConfigDialog::setFixedReference(
+        double elevation)
+{
+    ui->fixedReferenceEdit->setText(QString("%1").arg(elevation));
+}
+
+MainWindow::GroundReference ConfigDialog::groundReference() const
+{
+    if (ui->autoReferenceButton->isChecked()) return MainWindow::Automatic;
+    else                                      return MainWindow::Fixed;
+}
+
 void ConfigDialog::setMass(
         double mass)
 {

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -5,6 +5,7 @@
 #include <QDialog>
 #include <QListWidget>
 
+#include "mainwindow.h"
 #include "plotvalue.h"
 
 namespace Ui {
@@ -23,6 +24,12 @@ public:
 
     void setUnits(PlotValue::Units units);
     PlotValue::Units units() const;
+
+    void setGroundReference(MainWindow::GroundReference ref);
+    MainWindow::GroundReference groundReference() const;
+
+    double fixedReference() const;
+    void setFixedReference(double elevation);
 
     void setMass(double mass);
     double mass() const;

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -31,7 +31,7 @@
        <item>
         <widget class="QStackedWidget" name="pagesWidget">
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -55,6 +55,39 @@
               </widget>
              </item>
             </layout>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="title">
+              <string>Ground reference</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="autoReferenceButton">
+                <property name="text">
+                 <string>Automatic</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QRadioButton" name="fixedReferenceButton">
+                <property name="text">
+                 <string>Fixed</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="fixedReferenceEdit"/>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="fixedReferenceUnits">
+                <property name="text">
+                 <string>m</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
            <item>
             <spacer name="verticalSpacer">
@@ -208,7 +241,7 @@
            <item>
             <widget class="QTableWidget" name="plotTable">
              <attribute name="verticalHeaderVisible">
-              <bool>true</bool>
+              <bool>false</bool>
              </attribute>
             </widget>
            </item>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -44,6 +44,10 @@ public:
         Time, Distance, HorizontalSpeed, VerticalSpeed
     } OptimizationMode;
 
+    typedef enum {
+        Automatic, Fixed
+    } GroundReference;
+
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
@@ -225,6 +229,9 @@ private:
     double                mWindE, mWindN;
     bool                  mWindAdjustment;
 
+    GroundReference       mGroundReference;
+    double                mFixedReference;
+
     void writeSettings();
     void readSettings();
 
@@ -240,6 +247,7 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
+    void initAltitude();
     void updateVelocity();
     void initAerodynamics();
 


### PR DESCRIPTION
Added an option in Preferences to set the ground elevation automatically or to specify a fixed ground elevation.