### PR TITLE
Remove alt member from DataPoint

### DIFF
--- a/src/datapoint.cpp
+++ b/src/datapoint.cpp
@@ -33,7 +33,6 @@ DataPoint DataPoint::interpolate(
     ret.x = p1.x + a * (p2.x - p1.x);
     ret.y = p1.y + a * (p2.y - p1.y);
     ret.z = p1.z + a * (p2.z - p1.z);
-    ret.alt = p1.alt + a * (p2.alt - p1.alt);
 
     ret.dist2D = p1.dist2D + a * (p2.dist2D - p1.dist2D);
     ret.dist3D = p1.dist3D + a * (p2.dist3D - p1.dist3D);

--- a/src/datapoint.h
+++ b/src/datapoint.h
@@ -58,7 +58,7 @@ public:
 
     static double elevation(const DataPoint &dp)
     {
-        return dp.alt;
+        return dp.z;
     }
 
     static double northSpeed(const DataPoint &dp)

--- a/src/genome.cpp
+++ b/src/genome.cpp
@@ -191,7 +191,7 @@ QVector< DataPoint > Genome::simulate(
         pt.t = t;
         pt.x = x;
         pt.y = 0;
-        pt.z = pt.alt = y + dp0.alt - dp0.hMSL;
+        pt.z = y + dp0.z - dp0.hMSL;
 
         dist2D += dx;
         dist3D += sqrt(dx * dx + dy * dy);
@@ -207,7 +207,7 @@ QVector< DataPoint > Genome::simulate(
 
         result.append(pt);
 
-        if (pt.alt < windowBottom) break;
+        if (pt.z < windowBottom) break;
     }
 
     return result;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -500,7 +500,7 @@ void MainWindow::on_actionImport_triggered()
         m_data.append(pt);
     }
 
-    // Initialize time and altitude
+    // Initialize time
     for (int i = 0; i < m_data.size(); ++i)
     {
         const DataPoint &dp0 = m_data[m_data.size() - 1];
@@ -510,7 +510,6 @@ void MainWindow::on_actionImport_triggered()
         qint64 end = dp.dateTime.toMSecsSinceEpoch();
 
         dp.t = (double) (end - start) / 1000;
-        dp.z = dp.hMSL - dp0.hMSL;
     }
 
     // Altitude above ground
@@ -538,7 +537,7 @@ void MainWindow::initAltitude()
     for (int i = 0; i < m_data.size(); ++i)
     {
         DataPoint &dp = m_data[i];
-        dp.alt = dp.hMSL - mFixedReference;
+        dp.z = dp.hMSL - mFixedReference;
     }
 }
 
@@ -1499,7 +1498,6 @@ void MainWindow::setZero(
         dp.t -= dp0.t;
         dp.x -= dp0.x;
         dp.y -= dp0.y;
-        dp.z -= dp0.z;
 
         dp.dist2D -= dp0.dist2D;
         dp.dist3D -= dp0.dist3D;
@@ -1538,7 +1536,7 @@ void MainWindow::setGround(
     for (int i = 0; i < m_data.size(); ++i)
     {
         DataPoint &dp = m_data[i];
-        dp.alt -= dp0.alt;
+        dp.z -= dp0.z;
     }
 
     emit dataChanged();

--- a/src/ppcscoring.cpp
+++ b/src/ppcscoring.cpp
@@ -161,19 +161,19 @@ bool PPCScoring::getWindowBounds(
     {
         const DataPoint &dp = result[i];
 
-        if (dp.alt < mWindowBottom)
+        if (dp.z < mWindowBottom)
         {
             bottom = i;
             foundBottom = true;
         }
 
-        if (dp.alt < mWindowTop)
+        if (dp.z < mWindowTop)
         {
             top = i;
             foundTop = false;
         }
 
-        if (dp.alt > mWindowTop)
+        if (dp.z > mWindowTop)
         {
             foundTop = true;
         }
@@ -186,12 +186,12 @@ bool PPCScoring::getWindowBounds(
         // Calculate bottom of window
         const DataPoint &dp1 = result[bottom - 1];
         const DataPoint &dp2 = result[bottom];
-        dpBottom = DataPoint::interpolate(dp1, dp2, (mWindowBottom - dp1.alt) / (dp2.alt - dp1.alt));
+        dpBottom = DataPoint::interpolate(dp1, dp2, (mWindowBottom - dp1.z) / (dp2.z - dp1.z));
 
         // Calculate top of window
         const DataPoint &dp3 = result[top - 1];
         const DataPoint &dp4 = result[top];
-        dpTop = DataPoint::interpolate(dp3, dp4, (mWindowTop - dp3.alt) / (dp4.alt - dp3.alt));
+        dpTop = DataPoint::interpolate(dp3, dp4, (mWindowTop - dp3.z) / (dp4.z - dp3.z));
 
         return true;
     }

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -135,19 +135,19 @@ bool SpeedScoring::getWindowBounds(
     {
         const DataPoint &dp = result[i];
 
-        if (dp.alt < mWindowBottom)
+        if (dp.z < mWindowBottom)
         {
             bottom = i;
             foundBottom = true;
         }
 
-        if (dp.alt < mWindowTop)
+        if (dp.z < mWindowTop)
         {
             top = i;
             foundTop = false;
         }
 
-        if (dp.alt > mWindowTop)
+        if (dp.z > mWindowTop)
         {
             foundTop = true;
         }
@@ -160,12 +160,12 @@ bool SpeedScoring::getWindowBounds(
         // Calculate bottom of window
         const DataPoint &dp1 = result[bottom - 1];
         const DataPoint &dp2 = result[bottom];
-        dpBottom = DataPoint::interpolate(dp1, dp2, (mWindowBottom - dp1.alt) / (dp2.alt - dp1.alt));
+        dpBottom = DataPoint::interpolate(dp1, dp2, (mWindowBottom - dp1.z) / (dp2.z - dp1.z));
 
         // Calculate top of window
         const DataPoint &dp3 = result[top - 1];
         const DataPoint &dp4 = result[top];
-        dpTop = DataPoint::interpolate(dp3, dp4, (mWindowTop - dp3.alt) / (dp4.alt - dp3.alt));
+        dpTop = DataPoint::interpolate(dp3, dp4, (mWindowTop - dp3.z) / (dp4.z - dp3.z));
 
         return true;
     }


### PR DESCRIPTION
The ```alt``` and ```z``` members of ```DataPoint``` are largely redundant. The only difference seems to be that ```z``` has usually been relative to exit. However, it's hard to see how this is more useful than an altitude reference relative to ground, so the ```z``` member is now used for height above ground and the ```alt``` member has been removed.