### PR TITLE
Add shared memory import worker

### DIFF
--- a/src/FlySightViewer.pro
+++ b/src/FlySightViewer.pro
@@ -77,7 +77,8 @@ SOURCES += main.cpp \
     wideopendistanceform.cpp \
     wideopendistancescoring.cpp \
     wideopenspeedscoring.cpp \
-    geographicutil.cpp
+    geographicutil.cpp \
+    importworker.cpp
 
 HEADERS  += mainwindow.h \
     qcustomplot.h \
@@ -107,7 +108,8 @@ HEADERS  += mainwindow.h \
     wideopendistanceform.h \
     wideopendistancescoring.h \
     wideopenspeedscoring.h \
-    geographicutil.h
+    geographicutil.h \
+    importworker.h
 
 FORMS    += mainwindow.ui \
     configdialog.ui \

--- a/src/importworker.cpp
+++ b/src/importworker.cpp
@@ -1,0 +1,32 @@
+#include <QProcess>
+#include <QSharedMemory>
+#include <QSystemSemaphore>
+
+#include "importworker.h"
+
+ImportWorker::ImportWorker()
+{
+    // Initialize here
+}
+
+void ImportWorker::process()
+{
+    QSharedMemory shared("FlySight_Viewer_Import_Shared");
+    QSystemSemaphore free("FlySight_Viewer_Import_Free", 1, QSystemSemaphore::Open);
+    QSystemSemaphore used("FlySight_Viewer_Import_Used", 0, QSystemSemaphore::Open);
+
+    shared.create(1000);
+    shared.attach();
+
+    while (1)
+    {
+        used.acquire();
+
+        shared.lock();
+        QByteArray bytes((const char *) shared.constData(), shared.size());
+        emit importFile(QString::fromUtf8(bytes));
+        shared.unlock();
+
+        free.release();
+    }
+}

--- a/src/importworker.h
+++ b/src/importworker.h
@@ -1,0 +1,19 @@
+#ifndef IMPORTWORKER_H
+#define IMPORTWORKER_H
+
+#include <QObject>
+
+class ImportWorker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ImportWorker();
+
+signals:
+    void importFile(QString fileName);
+
+public slots:
+    void process();
+};
+
+#endif // IMPORTWORKER_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -10,6 +10,7 @@
 #include <QSettings>
 #include <QShortcut>
 #include <QTextStream>
+#include <QThread>
 
 #include <math.h>
 
@@ -18,6 +19,7 @@
 #include "common.h"
 #include "configdialog.h"
 #include "dataview.h"
+#include "importworker.h"
 #include "liftdragplot.h"
 #include "mapview.h"
 #include "orthoview.h"
@@ -121,6 +123,18 @@ MainWindow::MainWindow(
 
     // Redraw plots
     emit dataChanged();
+
+    // Create interprocess import worker
+    QThread *thread = new QThread;
+    ImportWorker *worker = new ImportWorker;
+    worker->moveToThread(thread);
+
+    // Attach interprocess import worker
+    connect(thread, SIGNAL(started()), worker, SLOT(process()));
+    connect(worker, SIGNAL(importFile(QString)), this, SLOT(importFile(QString)));
+
+    // Start worker thread
+    thread->start();
 }
 
 MainWindow::~MainWindow()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -130,8 +130,6 @@ public:
     bool updateReference(double lat, double lon);
     void closeReference();
 
-    void importFile(QString fileName);
-
 protected:
     void closeEvent(QCloseEvent *event);
 
@@ -268,6 +266,9 @@ signals:
     void cursorChanged();
     void aeroChanged();
     void rotationChanged(double rotation);
+
+public slots:
+    void importFile(QString fileName);
 
 private slots:
     void setScoringVisible(bool visible);


### PR DESCRIPTION
This pull request adds a shared memory import worker which can be used by external applications to force FlySight Viewer to import a file. This mechanism can be triggered using a block of code like this:

    // Inter-process communications
    QSharedMemory shared("FlySight_Viewer_Import_Shared");
    QSystemSemaphore free("FlySight_Viewer_Import_Free", 1, QSystemSemaphore::Open);
    QSystemSemaphore used("FlySight_Viewer_Import_Used", 0, QSystemSemaphore::Open);

    shared.create(1000);
    shared.attach();

    // Export to FlySight Viewer
    free.acquire();

    shared.lock();
    QChar *buf = (QChar *) shared.data();
    QByteArray bytes = exportedFile.toUtf8();
    memcpy(buf, bytes, bytes.size());
    shared.unlock();

    used.release();

    shared.detach();
