### PR TITLE
Fix colours

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -81,6 +81,30 @@ void ConfigDialog::on_browseButton_clicked()
     }
 }
 
+void ConfigDialog::on_defaultsButton_clicked()
+{
+    MainWindow *mainWindow = (MainWindow *) parent();
+
+    // Color list
+    QStringList colorNames = QColor::colorNames();
+
+    for (int i = 0; i < DataPlot::yaLast; ++i)
+    {
+        if (QComboBox *combo = (QComboBox *) ui->plotTable->cellWidget(i, PLOT_COLUMN_COLOUR))
+        {
+            PlotValue *yValue = mainWindow->plotArea()->yValue(i);
+            foreach (const QString &colorName, colorNames)
+            {
+                const QColor &color(colorName);
+                if (color == yValue->defaultColor())
+                {
+                    combo->setCurrentText(colorName);
+                }
+            }
+        }
+    }
+}
+
 void ConfigDialog::changePage(
         QListWidgetItem *current,
         QListWidgetItem *previous)

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -79,6 +79,7 @@ private:
 
 private slots:
     void on_browseButton_clicked();
+    void on_defaultsButton_clicked();
 
     void changePage(QListWidgetItem *current, QListWidgetItem *previous);
     void updatePlots();

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -31,7 +31,7 @@
        <item>
         <widget class="QStackedWidget" name="pagesWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -278,26 +278,37 @@
            <item>
             <widget class="QTableWidget" name="plotTable">
              <attribute name="verticalHeaderVisible">
-              <bool>false</bool>
+              <bool>true</bool>
              </attribute>
             </widget>
            </item>
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item>
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Line thickness:</string>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout" name="horizontalLayout_3">
+               <item>
+                <widget class="QLabel" name="label_2">
+                 <property name="text">
+                  <string>Line thickness:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lineThicknessEdit"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_3">
+                 <property name="text">
+                  <string>pixels</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineThicknessEdit"/>
-             </item>
-             <item>
-              <widget class="QLabel" name="label_3">
+              <widget class="QPushButton" name="defaultsButton">
                <property name="text">
-                <string>pixels</string>
+                <string>Default Colours</string>
                </property>
               </widget>
              </item>

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -23,7 +23,8 @@ public:
         Imperial
     } Units;
 
-    PlotValue(bool visible, QColor color): mVisible(visible), mColor(color),
+    PlotValue(bool visible, QColor color): mVisible(visible),
+        mColor(color), mDefaultColor(color),
         mMinimum(0), mMaximum(1), mUseMinimum(false), mUseMaximum(false) {}
 
     virtual const QString titleText() const = 0;
@@ -38,6 +39,7 @@ public:
 
     void setColor(const QColor &color) { mColor = color; }
     const QColor &color() const { return mColor; }
+    const QColor &defaultColor() const { return mDefaultColor; }
 
     double value(const DataPoint &dp, Units units) const
     {
@@ -110,6 +112,7 @@ public:
 private:
     bool     mVisible;
     QColor   mColor;
+    QColor   mDefaultColor;
     double   mMinimum, mMaximum;
     bool     mUseMinimum, mUseMaximum;
     QCPAxis *mAxis;

--- a/src/plotvalue.h
+++ b/src/plotvalue.h
@@ -84,7 +84,7 @@ public:
         QSettings settings("FlySight", "Viewer");
         settings.beginGroup("plotValue/" + key());
         mVisible = settings.value("visible", mVisible).toBool();
-        mColor = settings.value("color", mColor).value<QColor>();
+        mColor.setRgba(settings.value("rgba", mColor.rgba()).toUInt());
         mMinimum = settings.value("minimum", mMinimum).toDouble();
         mMaximum = settings.value("maximum", mMaximum).toDouble();
         mUseMinimum = settings.value("useMinimum", mUseMinimum).toBool();
@@ -97,7 +97,7 @@ public:
         QSettings settings("FlySight", "Viewer");
         settings.beginGroup("plotValue/" + key());
         settings.setValue("visible", mVisible);
-        settings.setValue("color", mColor);
+        settings.setValue("rgba", mColor.rgba());
         settings.setValue("minimum", mMinimum);
         settings.setValue("maximum", mMaximum);
         settings.setValue("useMinimum", mUseMinimum);


### PR DESCRIPTION
This change fixes an issue with colour preferences on MacOS. It seems that MacOS Sierra (10.12) has stopped supporting embedded nulls in string values. Unfortunately, Qt uses embedded nulls in its representation of variants. Therefore, I have changed the only value stored as a Variant--the colour for each plot--so that it uses an integer instead.