### PR TITLE
Fix flarescoring include casing

### DIFF
--- a/src/flareform.cpp
+++ b/src/flareform.cpp
@@ -8,7 +8,7 @@
 #include "datapoint.h"
 #include "mainwindow.h"
 #include "plotvalue.h"
-#include "FlareScoring.h"
+#include "flarescoring.h"
 
 FlareForm::FlareForm(QWidget *parent) :
     QWidget(parent),

--- a/src/flarescoring.cpp
+++ b/src/flarescoring.cpp
@@ -1,4 +1,4 @@
-#include "FlareScoring.h"
+#include "flarescoring.h"
 
 #include "mainwindow.h"
 


### PR DESCRIPTION
Fixes #87 

I noticed this while building [an AUR package](https://aur.archlinux.org/packages/flysight-viewer-qt-git/) for this project.

I'll remove [this patch](https://aur.archlinux.org/cgit/aur.git/tree/0002-Fix-libvlc-qt-library-naming.patch?h=flysight-viewer-qt-git) from the build once we get this merged.

Thanks in advance, and thanks for offering an awesome cross-platform solution!