### PR TITLE
Save exit, ground, course, wind and display range to database

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -34,8 +34,6 @@ ConfigDialog::ConfigDialog(MainWindow *mainWindow) :
                 QStringList() << tr("Aerodynamics"));
     ui->contentsWidget->addItems(
                 QStringList() << tr("Plots"));
-    ui->contentsWidget->addItems(
-                QStringList() << tr("Wind"));
 
     // Add units
     ui->unitsCombo->addItems(

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -29,6 +29,8 @@ ConfigDialog::ConfigDialog(MainWindow *mainWindow) :
     ui->contentsWidget->addItems(
                 QStringList() << tr("General"));
     ui->contentsWidget->addItems(
+                QStringList() << tr("Import"));
+    ui->contentsWidget->addItems(
                 QStringList() << tr("Aerodynamics"));
     ui->contentsWidget->addItems(
                 QStringList() << tr("Plots"));
@@ -50,6 +52,12 @@ ConfigDialog::ConfigDialog(MainWindow *mainWindow) :
     connect(ui->contentsWidget,
             SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)),
             this, SLOT(changePage(QListWidgetItem*,QListWidgetItem*)));
+
+    // Update reference when selection is changed
+    connect(ui->autoReferenceButton, SIGNAL(clicked(bool)),
+            this, SLOT(updateReference()));
+    connect(ui->fixedReferenceButton, SIGNAL(clicked(bool)),
+            this, SLOT(updateReference()));
 
     // Go to first page
     ui->contentsWidget->setCurrentRow(0);
@@ -175,6 +183,12 @@ void ConfigDialog::updatePlots()
     ui->plotTable->setVerticalHeaderLabels(verticalHeaderLabels);
 }
 
+void ConfigDialog::updateReference()
+{
+        ui->fixedReferenceEdit->setEnabled(ui->fixedReferenceButton->isChecked());
+    ui->fixedReferenceUnits->setEnabled(ui->fixedReferenceButton->isChecked());
+}
+
 void ConfigDialog::setUnits(
         PlotValue::Units units)
 {
@@ -191,6 +205,7 @@ void ConfigDialog::setGroundReference(
 {
     ui->autoReferenceButton->setChecked(ref == MainWindow::Automatic);
     ui->fixedReferenceButton->setChecked(ref == MainWindow::Fixed);
+    updateReference();
 }
 
 double ConfigDialog::fixedReference() const

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -83,6 +83,7 @@ private slots:
 
     void changePage(QListWidgetItem *current, QListWidgetItem *previous);
     void updatePlots();
+    void updateReference();
 };
 
 #endif // CONFIGDIALOG_H

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -31,7 +31,7 @@
        <item>
         <widget class="QStackedWidget" name="pagesWidget">
          <property name="currentIndex">
-          <number>1</number>
+          <number>3</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -144,6 +144,49 @@
             </widget>
            </item>
            <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="title">
+              <string>Wind</string>
+             </property>
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Speed:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLineEdit" name="windSpeedEdit"/>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="windUnitsLabel">
+                <property name="text">
+                 <string>units</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_11">
+                <property name="text">
+                 <string>Direction:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLineEdit" name="windDirectionEdit"/>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_17">
+                <property name="text">
+                 <string>deg</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_4">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -151,7 +194,7 @@
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>172</height>
+               <height>40</height>
               </size>
              </property>
             </spacer>
@@ -330,57 +373,6 @@
               </widget>
              </item>
             </layout>
-           </item>
-          </layout>
-         </widget>
-         <widget class="QWidget" name="wind">
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_10">
-             <property name="text">
-              <string>Wind speed:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="windSpeedEdit"/>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="windUnitsLabel">
-             <property name="text">
-              <string>units</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_11">
-             <property name="text">
-              <string>Wind direction:</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLineEdit" name="windDirectionEdit"/>
-           </item>
-           <item row="1" column="2">
-            <widget class="QLabel" name="label_17">
-             <property name="text">
-              <string>deg</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <spacer name="verticalSpacer_2">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>176</height>
-              </size>
-             </property>
-            </spacer>
            </item>
           </layout>
          </widget>

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -31,7 +31,7 @@
        <item>
         <widget class="QStackedWidget" name="pagesWidget">
          <property name="currentIndex">
-          <number>2</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="general">
           <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -94,11 +94,28 @@
             </layout>
            </item>
            <item>
-            <widget class="QGroupBox" name="groupBox">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>200</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="import_2">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QGroupBox" name="groupBox_2">
              <property name="title">
               <string>Ground reference</string>
              </property>
-             <layout class="QGridLayout" name="gridLayout_4">
+             <layout class="QGridLayout" name="gridLayout_7">
               <item row="0" column="0">
                <widget class="QRadioButton" name="autoReferenceButton">
                 <property name="text">
@@ -127,14 +144,14 @@
             </widget>
            </item>
            <item>
-            <spacer name="verticalSpacer">
+            <spacer name="verticalSpacer_4">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
                <width>20</width>
-               <height>200</height>
+               <height>172</height>
               </size>
              </property>
             </spacer>
@@ -278,7 +295,7 @@
            <item>
             <widget class="QTableWidget" name="plotTable">
              <attribute name="verticalHeaderVisible">
-              <bool>true</bool>
+              <bool>false</bool>
              </attribute>
             </widget>
            </item>

--- a/src/flarescoring.cpp
+++ b/src/flarescoring.cpp
@@ -19,7 +19,7 @@ void FlareScoring::setWindowBottom(
 }
 
 double FlareScoring::score(
-        const QVector< DataPoint > &result)
+        const MainWindow::DataPoints &result)
 {
     DataPoint dpBottom, dpTop;
     if (getWindowBounds(result, dpBottom, dpTop))
@@ -121,7 +121,7 @@ void FlareScoring::prepareDataPlot(
 }
 
 bool FlareScoring::getWindowBounds(
-        const QVector< DataPoint > &result,
+        const MainWindow::DataPoints &result,
         DataPoint &dpBottom,
         DataPoint &dpTop)
 {

--- a/src/flarescoring.h
+++ b/src/flarescoring.h
@@ -13,12 +13,12 @@ public:
     double windowBottom(void) const { return mWindowBottom; }
     void setWindowBottom(double windowBottom);
 
-    double score(const QVector< DataPoint > &result);
+    double score(const MainWindow::DataPoints &result);
     QString scoreAsText(double score);
 
     void prepareDataPlot(DataPlot *plot);
 
-    bool getWindowBounds(const QVector< DataPoint > &result,
+    bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom, DataPoint &dpTop);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }

--- a/src/genome.cpp
+++ b/src/genome.cpp
@@ -115,7 +115,7 @@ void Genome::truncate(
     append(QVector< double >(partSize, last()));
 }
 
-QVector< DataPoint > Genome::simulate(
+MainWindow::DataPoints Genome::simulate(
         double h,
         double a,
         double c,
@@ -134,7 +134,7 @@ QVector< DataPoint > Genome::simulate(
     double dist2D = dp0.dist2D;
     double dist3D = dp0.dist3D;
 
-    QVector< DataPoint > result(1, dp0);
+    MainWindow::DataPoints result(1, dp0);
 
     for (int i = 0; i < size(); ++i)
     {

--- a/src/genome.h
+++ b/src/genome.h
@@ -4,6 +4,7 @@
 #include <QVector>
 
 #include "datapoint.h"
+#include "mainwindow.h"
 
 class Genome:
         public QVector< double >
@@ -16,7 +17,7 @@ public:
 
     void mutate(int k, int kMin, double minLift, double maxLift);
     void truncate(int k);
-    QVector< DataPoint > simulate(double h, double a, double c,
+    MainWindow::DataPoints simulate(double h, double a, double c,
                                   double planformArea, double mass,
                                   const DataPoint &dp0, double windowBottom);
 

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -208,7 +208,7 @@ void LogbookView::updateView()
         ui->tableWidget->setItem(index, 14, new RealItem(QString::number(ground, 'f', 3)));     // ground
         ui->tableWidget->setItem(index, 15, new RealItem(QString::number(course, 'f', 5)));     // course
         ui->tableWidget->setItem(index, 16, new RealItem(QString::number(windSpeed, 'f', 2)));  // wind_speed
-        ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 2)));    // wind_dir
+        ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 5)));    // wind_dir
 
         for (int j = 0; j < 18; ++j)
         {

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -119,20 +119,24 @@ void LogbookView::updateView()
 
     ui->tableWidget->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft);
 
-    ui->tableWidget->setColumnCount(query.record().count() + 1);
+    ui->tableWidget->setColumnCount(query.record().count() + 2);
     ui->tableWidget->setRowCount(0);
 
     ui->tableWidget->setColumnWidth(0, ui->tableWidget->horizontalHeader()->minimumSectionSize());
     ui->tableWidget->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
 
-    ui->tableWidget->setColumnHidden(1, true);  // Hide id column
-    ui->tableWidget->setColumnHidden(2, true);  // Hide file_name column
-    ui->tableWidget->setColumnHidden(7, true);  // Hide min_lat column
-    ui->tableWidget->setColumnHidden(8, true);  // Hide max_lat column
-    ui->tableWidget->setColumnHidden(9, true);  // Hide min_lon column
-    ui->tableWidget->setColumnHidden(10, true);  // Hide max_lon column
+    ui->tableWidget->setColumnWidth(1, 2 * ui->tableWidget->horizontalHeader()->minimumSectionSize());
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
+
+    ui->tableWidget->setColumnHidden(2, true);  // Hide id column
+    ui->tableWidget->setColumnHidden(3, true);  // Hide file_name column
+    ui->tableWidget->setColumnHidden(8, true);  // Hide min_lat column
+    ui->tableWidget->setColumnHidden(9, true);  // Hide max_lat column
+    ui->tableWidget->setColumnHidden(10, true);  // Hide min_lon column
+    ui->tableWidget->setColumnHidden(11, true);  // Hide max_lon column
 
     ui->tableWidget->setHorizontalHeaderLabels(QStringList()
+                                               << tr("")
                                                << tr("")
                                                << tr("ID")
                                                << tr("File Name")
@@ -166,23 +170,25 @@ void LogbookView::updateView()
             ui->tableWidget->setItem(index, 0, new QTableWidgetItem);
         }
 
-        ui->tableWidget->setItem(index, 1, new IntItem(query.value(0).toString()));             // id
-        ui->tableWidget->setItem(index, 2, new QTableWidgetItem(query.value(1).toString()));    // file_name
-        ui->tableWidget->setItem(index, 3, new QTableWidgetItem(query.value(2).toString()));    // description
-        ui->tableWidget->setItem(index, 4, new TimeItem(startTime));                            // start_time
-        ui->tableWidget->setItem(index, 5, new DurationItem(duration));                         // duration
-        ui->tableWidget->setItem(index, 6, new IntItem(query.value(5).toString()));             // sample_period
-        ui->tableWidget->setItem(index, 7, new IntItem(query.value(6).toString()));             // min_lat
-        ui->tableWidget->setItem(index, 8, new IntItem(query.value(7).toString()));             // max_lat
-        ui->tableWidget->setItem(index, 9, new IntItem(query.value(8).toString()));             // min_lon
-        ui->tableWidget->setItem(index, 10, new IntItem(query.value(9).toString()));            // max_lon
-        ui->tableWidget->setItem(index, 11, new TimeItem(importTime));                          // import_time
+        ui->tableWidget->setItem(index, 1, new QTableWidgetItem);
 
-        for (int j = 0; j < 12; ++j)
+        ui->tableWidget->setItem(index, 2, new IntItem(query.value(0).toString()));             // id
+        ui->tableWidget->setItem(index, 3, new QTableWidgetItem(query.value(1).toString()));    // file_name
+        ui->tableWidget->setItem(index, 4, new QTableWidgetItem(query.value(2).toString()));    // description
+        ui->tableWidget->setItem(index, 5, new TimeItem(startTime));                            // start_time
+        ui->tableWidget->setItem(index, 6, new DurationItem(duration));                         // duration
+        ui->tableWidget->setItem(index, 7, new IntItem(query.value(5).toString()));             // sample_period
+        ui->tableWidget->setItem(index, 8, new IntItem(query.value(6).toString()));             // min_lat
+        ui->tableWidget->setItem(index, 9, new IntItem(query.value(7).toString()));             // max_lat
+        ui->tableWidget->setItem(index, 10, new IntItem(query.value(8).toString()));            // min_lon
+        ui->tableWidget->setItem(index, 11, new IntItem(query.value(9).toString()));            // max_lon
+        ui->tableWidget->setItem(index, 12, new TimeItem(importTime));                          // import_time
+
+        for (int j = 0; j < 13; ++j)
         {
             // Disable editing on every column except description
             QTableWidgetItem *item = ui->tableWidget->item(index, j);
-            if (j == 3) item->setFlags(item->flags() |  Qt::ItemIsEditable);
+            if (j == 4) item->setFlags(item->flags() |  Qt::ItemIsEditable);
             else        item->setFlags(item->flags() & ~Qt::ItemIsEditable);
         }
 
@@ -198,7 +204,7 @@ void LogbookView::onDoubleClick(
 {
     Q_UNUSED(column);
 
-    mMainWindow->importFromDatabase(ui->tableWidget->item(row, 2)->text());
+    mMainWindow->importFromDatabase(ui->tableWidget->item(row, 3)->text());
 }
 
 void LogbookView::onSelectionChanged()
@@ -216,7 +222,7 @@ void LogbookView::onSelectionChanged()
     QVector< QString > selectedFiles;
     foreach (int row, selectedRows)
     {
-        QTableWidgetItem *item = ui->tableWidget->item(row, 2);
+        QTableWidgetItem *item = ui->tableWidget->item(row, 3);
         selectedFiles.append(item->text());
     }
 
@@ -228,10 +234,10 @@ void LogbookView::onItemChanged(
         QTableWidgetItem *item)
 {
     // Return if not editing description
-    if (item->column() != 3) return;
+    if (item->column() != 4) return;
 
     // Get file name
-    QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 2);
+    QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
     if (!nameItem) return;
 
     // Update description

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -168,8 +168,13 @@ void LogbookView::updateView()
         qint64 duration = query.value(4).toString().toLongLong();
         double ground = query.value(12).toString().toDouble();
         double course = query.value(13).toString().toDouble();
-        double windSpeed = query.value(14).toString().toDouble();
-        double windDir = query.value(15).toString().toDouble();
+
+        double windE = query.value(14).toString().toDouble();
+        double windN = query.value(15).toString().toDouble();
+
+        double windSpeed = sqrt(windE * windE + windN * windN);
+        double windDir = atan2(-windE, -windN) / PI * 180;
+        if (windDir < 0) windDir += 360;
 
         if (mMainWindow->trackName() == query.value(1).toString())
         {
@@ -203,7 +208,7 @@ void LogbookView::updateView()
         ui->tableWidget->setItem(index, 14, new RealItem(QString::number(ground, 'f', 3)));     // ground
         ui->tableWidget->setItem(index, 15, new RealItem(QString::number(course, 'f', 5)));     // course
         ui->tableWidget->setItem(index, 16, new RealItem(QString::number(windSpeed, 'f', 2)));  // wind_speed
-        ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 5)));    // wind_dir
+        ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 2)));    // wind_dir
 
         for (int j = 0; j < 18; ++j)
         {

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -129,6 +129,7 @@ void LogbookView::updateView()
     ui->tableWidget->setColumnWidth(1, 2 * ui->tableWidget->horizontalHeader()->minimumSectionSize());
     ui->tableWidget->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Fixed);
 
+    ui->tableWidget->setColumnHidden(1, true);  // Hide checked column
     ui->tableWidget->setColumnHidden(2, true);  // Hide id column
     ui->tableWidget->setColumnHidden(3, true);  // Hide file_name column
     ui->tableWidget->setColumnHidden(8, true);  // Hide min_lat column

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -137,6 +137,9 @@ void LogbookView::updateView()
     ui->tableWidget->setColumnHidden(11, true);  // Hide max_lon column
     ui->tableWidget->setColumnHidden(15, true);  // Hide course column
 
+    ui->tableWidget->setColumnHidden(18, true);  // Hide min_t column
+    ui->tableWidget->setColumnHidden(19, true);  // Hide max_t column
+
     ui->tableWidget->setHorizontalHeaderLabels(QStringList()
                                                << tr("")
                                                << tr("")
@@ -155,7 +158,9 @@ void LogbookView::updateView()
                                                << tr("Ground Elev")
                                                << tr("Course Angle")
                                                << tr("Wind Speed")
-                                               << tr("Wind Dir"));
+                                               << tr("Wind Dir")
+                                               << tr("Range Lower")
+                                               << tr("Range Upper"));
 
     int index = 0;
     while (query.next())
@@ -175,6 +180,9 @@ void LogbookView::updateView()
         double windSpeed = sqrt(windE * windE + windN * windN);
         double windDir = atan2(-windE, -windN) / PI * 180;
         if (windDir < 0) windDir += 360;
+
+        QDateTime rangeLower = QDateTime::fromString(query.value(16).toString(), Qt::ISODate);
+        QDateTime rangeUpper = QDateTime::fromString(query.value(17).toString(), Qt::ISODate);
 
         if (mMainWindow->trackName() == query.value(1).toString())
         {
@@ -209,8 +217,10 @@ void LogbookView::updateView()
         ui->tableWidget->setItem(index, 15, new RealItem(QString::number(course, 'f', 5)));     // course
         ui->tableWidget->setItem(index, 16, new RealItem(QString::number(windSpeed, 'f', 2)));  // wind_speed
         ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 5)));    // wind_dir
+        ui->tableWidget->setItem(index, 18, new TimeItem(rangeLower));                          // t_min
+        ui->tableWidget->setItem(index, 19, new TimeItem(rangeUpper));                          // t_max
 
-        for (int j = 0; j < 18; ++j)
+        for (int j = 0; j < ui->tableWidget->columnCount(); ++j)
         {
             // Enable/disable editing
             QTableWidgetItem *item = ui->tableWidget->item(index, j);

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -27,7 +27,7 @@ class TimeItem : public QTableWidgetItem
 {
 public:
     TimeItem(const QDateTime &dateTime, int type = Type):
-        QTableWidgetItem(dateTime.toUTC().toString("yyyy/MM/dd h:mm A"), type)
+        QTableWidgetItem(dateTime.toLocalTime().toString("yyyy/MM/dd h:mm A"), type)
     {
         setData(Qt::UserRole, dateTime);
     }

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -280,33 +280,35 @@ void LogbookView::onItemChanged(
 {
     if (suspendItemChanged) return;
 
+    // Get file name
+    QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
+    if (!nameItem) return;
+
     if (item->column() == 1)
     {
-        // Get file name
-        QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
-        if (!nameItem) return;
-
         // Update check state
         mMainWindow->setTrackChecked(nameItem->text(),
                                      item->checkState() == Qt::Checked);
     }
     else if (item->column() == 4)
     {
-        // Get file name
-        QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
-        if (!nameItem) return;
-
         // Update description
         mMainWindow->setTrackDescription(nameItem->text(), item->text());
     }
     else if (item->column() == 14)
     {
-        // Get file name
-        QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
-        if (!nameItem) return;
-
         // Update ground elevation
         mMainWindow->setTrackGround(nameItem->text(), item->text().toDouble());
+    }
+    else if (item->column() == 16)
+    {
+        // Update wind speed
+        mMainWindow->setTrackWindSpeed(nameItem->text(), item->text().toDouble());
+    }
+    else if (item->column() == 17)
+    {
+        // Update wind direction
+        mMainWindow->setTrackWindDir(nameItem->text(), item->text().toDouble());
     }
 }
 

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -11,15 +11,15 @@
 
 #include "mainwindow.h"
 
-class IntItem : public QTableWidgetItem
+class RealItem : public QTableWidgetItem
 {
 public:
-    IntItem(const QString &text, int type = Type):
+    RealItem(const QString &text, int type = Type):
         QTableWidgetItem(text, type) {}
 
     bool operator<(const QTableWidgetItem &rhs) const
     {
-        return (this->text().toInt() < rhs.text().toInt());
+        return (this->text().toDouble() < rhs.text().toDouble());
     }
 };
 
@@ -174,16 +174,16 @@ void LogbookView::updateView()
                                 query.value(1).toString()) ? Qt::Checked : Qt::Unchecked);
         ui->tableWidget->setItem(index, 1, item);
 
-        ui->tableWidget->setItem(index, 2, new IntItem(query.value(0).toString()));             // id
+        ui->tableWidget->setItem(index, 2, new RealItem(query.value(0).toString()));             // id
         ui->tableWidget->setItem(index, 3, new QTableWidgetItem(query.value(1).toString()));    // file_name
         ui->tableWidget->setItem(index, 4, new QTableWidgetItem(query.value(2).toString()));    // description
         ui->tableWidget->setItem(index, 5, new TimeItem(startTime));                            // start_time
         ui->tableWidget->setItem(index, 6, new DurationItem(duration));                         // duration
-        ui->tableWidget->setItem(index, 7, new IntItem(query.value(5).toString()));             // sample_period
-        ui->tableWidget->setItem(index, 8, new IntItem(query.value(6).toString()));             // min_lat
-        ui->tableWidget->setItem(index, 9, new IntItem(query.value(7).toString()));             // max_lat
-        ui->tableWidget->setItem(index, 10, new IntItem(query.value(8).toString()));            // min_lon
-        ui->tableWidget->setItem(index, 11, new IntItem(query.value(9).toString()));            // max_lon
+        ui->tableWidget->setItem(index, 7, new RealItem(query.value(5).toString()));             // sample_period
+        ui->tableWidget->setItem(index, 8, new RealItem(query.value(6).toString()));             // min_lat
+        ui->tableWidget->setItem(index, 9, new RealItem(query.value(7).toString()));             // max_lat
+        ui->tableWidget->setItem(index, 10, new RealItem(query.value(8).toString()));            // min_lon
+        ui->tableWidget->setItem(index, 11, new RealItem(query.value(9).toString()));            // max_lon
         ui->tableWidget->setItem(index, 12, new TimeItem(importTime));                          // import_time
 
         for (int j = 0; j < 13; ++j)

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -170,7 +170,10 @@ void LogbookView::updateView()
             ui->tableWidget->setItem(index, 0, new QTableWidgetItem);
         }
 
-        ui->tableWidget->setItem(index, 1, new QTableWidgetItem);
+        QTableWidgetItem *item = new QTableWidgetItem;
+        item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
+        item->setCheckState(Qt::Unchecked);
+        ui->tableWidget->setItem(index, 1, item);
 
         ui->tableWidget->setItem(index, 2, new IntItem(query.value(0).toString()));             // id
         ui->tableWidget->setItem(index, 3, new QTableWidgetItem(query.value(1).toString()));    // file_name

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -27,7 +27,7 @@ class TimeItem : public QTableWidgetItem
 {
 public:
     TimeItem(const QDateTime &dateTime, int type = Type):
-        QTableWidgetItem(dateTime.toString("yyyy/MM/dd h:mm A"), type)
+        QTableWidgetItem(dateTime.toUTC().toString("yyyy/MM/dd h:mm A"), type)
     {
         setData(Qt::UserRole, dateTime);
     }
@@ -160,9 +160,9 @@ void LogbookView::updateView()
     {
         ui->tableWidget->insertRow(ui->tableWidget->rowCount());
 
-        QDateTime startTime = QDateTime::fromString(query.value(3).toString(), "yyyy-MM-dd HH:mm:ss.zzz");
-        QDateTime importTime = QDateTime::fromString(query.value(10).toString(), "yyyy-MM-dd HH:mm:ss.zzz");
-        QDateTime exitTime = QDateTime::fromString(query.value(11).toString(), "yyyy-MM-dd HH:mm:ss.zzz");
+        QDateTime startTime = QDateTime::fromString(query.value(3).toString(), Qt::ISODate);
+        QDateTime importTime = QDateTime::fromString(query.value(10).toString(), Qt::ISODate);
+        QDateTime exitTime = QDateTime::fromString(query.value(11).toString(), Qt::ISODate);
         qint64 duration = query.value(4).toString().toLongLong();
 
         if (mMainWindow->trackName() == query.value(1).toString())

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -153,7 +153,9 @@ void LogbookView::updateView()
                                                << tr("Import Time")
                                                << tr("Exit Time")
                                                << tr("Ground Elev")
-                                               << tr("Course Angle"));
+                                               << tr("Course Angle")
+                                               << tr("Wind Speed")
+                                               << tr("Wind Dir"));
 
     int index = 0;
     while (query.next())
@@ -166,6 +168,8 @@ void LogbookView::updateView()
         qint64 duration = query.value(4).toString().toLongLong();
         double ground = query.value(12).toString().toDouble();
         double course = query.value(13).toString().toDouble();
+        double windSpeed = query.value(14).toString().toDouble();
+        double windDir = query.value(15).toString().toDouble();
 
         if (mMainWindow->trackName() == query.value(1).toString())
         {
@@ -198,13 +202,26 @@ void LogbookView::updateView()
         ui->tableWidget->setItem(index, 13, new TimeItem(exitTime));                            // exit_time
         ui->tableWidget->setItem(index, 14, new RealItem(QString::number(ground, 'f', 3)));     // ground
         ui->tableWidget->setItem(index, 15, new RealItem(QString::number(course, 'f', 5)));     // course
+        ui->tableWidget->setItem(index, 16, new RealItem(QString::number(windSpeed, 'f', 2)));  // wind_speed
+        ui->tableWidget->setItem(index, 17, new RealItem(QString::number(windDir, 'f', 5)));    // wind_dir
 
-        for (int j = 0; j < 16; ++j)
+        for (int j = 0; j < 18; ++j)
         {
-            // Disable editing on every column except description and ground
+            // Enable/disable editing
             QTableWidgetItem *item = ui->tableWidget->item(index, j);
-            if (j == 4 || j == 14) item->setFlags(item->flags() |  Qt::ItemIsEditable);
-            else                   item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+
+            switch (j)
+            {
+            case 4:  // description
+            case 14: // ground
+            case 16: // wind_speed
+            case 17: // wind_dir
+                item->setFlags(item->flags() |  Qt::ItemIsEditable);
+                break;
+            default:
+                item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+                break;
+            }
         }
 
         ++index;

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -206,7 +206,18 @@ void LogbookView::onDoubleClick(
 {
     Q_UNUSED(column);
 
-    mMainWindow->importFromDatabase(ui->tableWidget->item(row, 3)->text());
+    // Get file name
+    QTableWidgetItem *nameItem = ui->tableWidget->item(row, 3);
+    if (!nameItem) return;
+
+    if (mMainWindow->trackChecked(nameItem->text()))
+    {
+        mMainWindow->importFromCheckedTrack(nameItem->text());
+    }
+    else
+    {
+        mMainWindow->importFromDatabase(nameItem->text());
+    }
 }
 
 void LogbookView::onSelectionChanged()

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -65,8 +65,6 @@ LogbookView::LogbookView(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    updateView();
-
     connect(ui->tableWidget, SIGNAL(cellDoubleClicked(int,int)),
             this, SLOT(onDoubleClick(int,int)));
     connect(ui->tableWidget, SIGNAL(itemSelectionChanged()),
@@ -159,7 +157,7 @@ void LogbookView::updateView()
         QDateTime importTime = QDateTime::fromString(query.value(10).toString(), "yyyy-MM-dd HH:mm:ss.zzz");
         qint64 duration = query.value(4).toString().toLongLong();
 
-        if (mMainWindow && mMainWindow->trackName() == query.value(1).toString())
+        if (mMainWindow->trackName() == query.value(1).toString())
         {
             QTableWidgetItem *item = new QTableWidgetItem;
             item->setIcon(style()->standardIcon(QStyle::SP_MediaPlay));
@@ -172,7 +170,8 @@ void LogbookView::updateView()
 
         QTableWidgetItem *item = new QTableWidgetItem;
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
-        item->setCheckState(Qt::Unchecked);
+        item->setCheckState(mMainWindow->trackChecked(
+                                query.value(1).toString()) ? Qt::Checked : Qt::Unchecked);
         ui->tableWidget->setItem(index, 1, item);
 
         ui->tableWidget->setItem(index, 2, new IntItem(query.value(0).toString()));             // id
@@ -236,15 +235,25 @@ void LogbookView::onSelectionChanged()
 void LogbookView::onItemChanged(
         QTableWidgetItem *item)
 {
-    // Return if not editing description
-    if (item->column() != 4) return;
+    if (item->column() == 1)
+    {
+        // Get file name
+        QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
+        if (!nameItem) return;
 
-    // Get file name
-    QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
-    if (!nameItem) return;
+        // Update check state
+        mMainWindow->setTrackChecked(nameItem->text(),
+                                     item->checkState() == Qt::Checked);
+    }
+    else if (item->column() == 4)
+    {
+        // Get file name
+        QTableWidgetItem *nameItem = ui->tableWidget->item(item->row(), 3);
+        if (!nameItem) return;
 
-    // Update description
-    mMainWindow->setTrackDescription(nameItem->text(), item->text());
+        // Update description
+        mMainWindow->setTrackDescription(nameItem->text(), item->text());
+    }
 }
 
 void LogbookView::onSearchTextChanged(

--- a/src/logbookview.cpp
+++ b/src/logbookview.cpp
@@ -164,6 +164,8 @@ void LogbookView::updateView()
         QDateTime importTime = QDateTime::fromString(query.value(10).toString(), Qt::ISODate);
         QDateTime exitTime = QDateTime::fromString(query.value(11).toString(), Qt::ISODate);
         qint64 duration = query.value(4).toString().toLongLong();
+        double ground = query.value(12).toString().toDouble();
+        double course = query.value(13).toString().toDouble();
 
         if (mMainWindow->trackName() == query.value(1).toString())
         {
@@ -194,8 +196,8 @@ void LogbookView::updateView()
         ui->tableWidget->setItem(index, 11, new RealItem(query.value(9).toString()));            // max_lon
         ui->tableWidget->setItem(index, 12, new TimeItem(importTime));                          // import_time
         ui->tableWidget->setItem(index, 13, new TimeItem(exitTime));                            // exit_time
-        ui->tableWidget->setItem(index, 14, new RealItem(query.value(12).toString()));           // ground
-        ui->tableWidget->setItem(index, 15, new RealItem(query.value(13).toString()));           // course
+        ui->tableWidget->setItem(index, 14, new RealItem(QString::number(ground, 'f', 3)));     // ground
+        ui->tableWidget->setItem(index, 15, new RealItem(QString::number(course, 'f', 5)));     // course
 
         for (int j = 0; j < 16; ++j)
         {

--- a/src/logbookview.h
+++ b/src/logbookview.h
@@ -27,6 +27,8 @@ private:
     Ui::LogbookView *ui;
     MainWindow      *mMainWindow;
 
+    bool             suspendItemChanged;
+
 public slots:
     void updateView();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -438,6 +438,7 @@ void MainWindow::initLogbookView()
     addDockWidget(Qt::BottomDockWidgetArea, dockWidget);
 
     logbookView->setMainWindow(this);
+    logbookView->updateView();
 
     connect(m_ui->actionShowLogbookView, SIGNAL(toggled(bool)),
             dockWidget, SLOT(setVisible(bool)));
@@ -768,6 +769,20 @@ void MainWindow::setTrackDescription(
     }
 
     emit databaseChanged();
+}
+
+void MainWindow::setTrackChecked(
+        const QString &trackName,
+        bool checked)
+{
+    if (checked) mCheckedTracks.insert(trackName);
+    else         mCheckedTracks.remove(trackName);
+}
+
+bool MainWindow::trackChecked(
+        const QString &trackName) const
+{
+    return mCheckedTracks.contains(trackName);
 }
 
 void MainWindow::import(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -795,19 +795,26 @@ void MainWindow::setTrackChecked(
     {
         DataPoints data;
 
-        // Get name of file in database
-        QString newName = QString("FlySight/Tracks/%1.csv").arg(trackName);
-        QString newPath = QDir(mDatabasePath).filePath(newName);
-
-        QFile file(newPath);
-        if (!file.open(QIODevice::ReadOnly))
+        if (trackName == mTrackName)
         {
-            QMessageBox::critical(0, tr("Import failed"), tr("Couldn't read file"));
-            return;
+            data = m_data;
         }
+        else
+        {
+            // Get name of file in database
+            QString newName = QString("FlySight/Tracks/%1.csv").arg(trackName);
+            QString newPath = QDir(mDatabasePath).filePath(newName);
 
-        // Read file data
-        import(&file, data);
+            QFile file(newPath);
+            if (!file.open(QIODevice::ReadOnly))
+            {
+                QMessageBox::critical(0, tr("Import failed"), tr("Couldn't read file"));
+                return;
+            }
+
+            // Read file data
+            import(&file, data);
+        }
 
         mCheckedTracks.insert(trackName, data);
     }
@@ -823,6 +830,24 @@ bool MainWindow::trackChecked(
         const QString &trackName) const
 {
     return mCheckedTracks.contains(trackName);
+}
+
+void MainWindow::importFromCheckedTrack(
+        const QString &uniqueName)
+{
+    // Copy track data
+    m_data = mCheckedTracks[uniqueName];
+
+    // Clear optimum
+    m_optimal.clear();
+
+    // Initialize plot ranges
+    initRange();
+
+    emit dataLoaded();
+
+    // Remember current track
+    setTrackName(uniqueName);
 }
 
 void MainWindow::import(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -777,6 +777,8 @@ void MainWindow::setTrackChecked(
 {
     if (checked) mCheckedTracks.insert(trackName);
     else         mCheckedTracks.remove(trackName);
+
+    emit dataChanged();
 }
 
 bool MainWindow::trackChecked(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -977,24 +977,21 @@ void MainWindow::initAltitude(
         DataPoints &data,
         QString trackName)
 {
+    double ground;
     if (mGroundReference == Automatic)
     {
-        QString value;
-        if (getDatabaseValue(trackName, "ground", value))
-        {
-            mFixedReference = value.toDouble();
-        }
-        else
-        {
-            const DataPoint &dp0 = data[data.size() - 1];
-            mFixedReference = dp0.hMSL;
-        }
+        const DataPoint &dp0 = data[data.size() - 1];
+        ground = dp0.hMSL;
+    }
+    else
+    {
+        ground = mFixedReference;
     }
 
     for (int i = 0; i < data.size(); ++i)
     {
         DataPoint &dp = data[i];
-        dp.z = dp.hMSL - mFixedReference;
+        dp.z = dp.hMSL - ground;
     }
 }
 
@@ -1694,20 +1691,6 @@ void MainWindow::on_actionPreferences_triggered()
         {
             mGroundReference = dlg.groundReference();
             mFixedReference = dlg.fixedReference();
-
-            // Update plot data
-            initAltitude(m_data, mTrackName);
-
-            // Update checked tracks
-            QMap< QString, DataPoints >::iterator p;
-            for (p = mCheckedTracks.begin();
-                 p != mCheckedTracks.end();
-                 ++p)
-            {
-                initAltitude(p.value(), p.key());
-            }
-
-            emit dataChanged();
         }
 
         if (mDatabasePath != dlg.databasePath())

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2043,17 +2043,46 @@ void MainWindow::setGround(
     if (m_data.isEmpty()) return;
 
     DataPoint dp0 = interpolateDataT(t);
-    setDatabaseValue(mTrackName, "ground", QString::number(dp0.hMSL, 'f', 3));
-
-    for (int i = 0; i < m_data.size(); ++i)
-    {
-        DataPoint &dp = m_data[i];
-        dp.z -= dp0.z;
-    }
-
-    emit dataChanged();
+    setTrackGround(mTrackName, dp0.hMSL);
 
     setTool(mPrevTool);
+}
+
+void MainWindow::setTrackGround(
+        QString trackName,
+        double ground)
+{
+    setDatabaseValue(trackName, "ground", QString::number(ground, 'f', 3));
+
+    // Update current track
+    if (trackName == mTrackName)
+    {
+        updateGround(m_data, ground);
+        emit dataChanged();
+    }
+
+    // Update checked tracks
+    QMap< QString, DataPoints >::iterator p;
+    for (p = mCheckedTracks.begin();
+         p != mCheckedTracks.end();
+         ++p)
+    {
+        if (trackName == p.key())
+        {
+            updateGround(p.value(), ground);
+        }
+    }
+}
+
+void MainWindow::updateGround(
+        DataPoints &data,
+        double ground)
+{
+    for (int i = 0; i < data.size(); ++i)
+    {
+        DataPoint &dp = data[i];
+        dp.z = dp.hMSL - ground;
+    }
 }
 
 void MainWindow::setCourse(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -938,22 +938,27 @@ void MainWindow::import(
     }
 
     // Initialize time
-    for (int i = 0; i < data.size(); ++i)
-    {
-        const DataPoint &dp0 = data[data.size() - 1];
-        DataPoint &dp = data[i];
-
-        qint64 start = dp0.dateTime.toMSecsSinceEpoch();
-        qint64 end = dp.dateTime.toMSecsSinceEpoch();
-
-        dp.t = (double) (end - start) / 1000;
-    }
+    initTime(data);
 
     // Altitude above ground
     initAltitude(data);
 
     // Wind adjustments
     updateVelocity(data);
+}
+
+void MainWindow::initTime(
+        DataPoints &data)
+{
+    const DataPoint &dp0 = data[data.size() - 1];
+    qint64 start = dp0.dateTime.toMSecsSinceEpoch();
+
+    for (int i = 0; i < data.size(); ++i)
+    {
+        DataPoint &dp = data[i];
+        qint64 end = dp.dateTime.toMSecsSinceEpoch();
+        dp.t = (double) (end - start) / 1000;
+    }
 }
 
 void MainWindow::initAltitude(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1055,7 +1055,7 @@ void MainWindow::updateVelocity(
         bool initDatabase)
 {
     double windE, windN;
-    getWind(&windE, &windN);
+    getWind(trackName, &windE, &windN);
 
     if (initDatabase)
     {
@@ -2144,7 +2144,7 @@ void MainWindow::setTrackWindSpeed(
         double windSpeed)
 {
     double windSpeedOld, windDir;
-    getWindSpeedDirection(&windSpeedOld, &windDir);
+    getWindSpeedDirection(trackName, &windSpeedOld, &windDir);
 
     double windE, windN;
     windE = -windSpeed * sin(windDir / 180 * PI);
@@ -2178,7 +2178,7 @@ void MainWindow::setTrackWindDir(
         double windDir)
 {
     double windSpeed, windDirOld;
-    getWindSpeedDirection(&windSpeed, &windDirOld);
+    getWindSpeedDirection(trackName, &windSpeed, &windDirOld);
 
     double windE, windN;
     windE = -windSpeed * sin(windDir / 180 * PI);
@@ -2386,12 +2386,13 @@ void MainWindow::setWind(
 }
 
 void MainWindow::getWind(
+        QString trackName,
         double *windE,
         double *windN)
 {
     QString strE, strN;
-    if (getDatabaseValue(mTrackName, "wind_e", strE)
-            && getDatabaseValue(mTrackName, "wind_n", strN))
+    if (getDatabaseValue(trackName, "wind_e", strE)
+            && getDatabaseValue(trackName, "wind_n", strN))
     {
         *windE = strE.toDouble();
         *windN = strN.toDouble();
@@ -2404,11 +2405,12 @@ void MainWindow::getWind(
 }
 
 void MainWindow::getWindSpeedDirection(
+        QString trackName,
         double *windSpeed,
         double *windDirection)
 {
     double windE, windN;
-    getWind(&windE, &windN);
+    getWind(trackName, &windE, &windN);
 
     *windSpeed = sqrt(windE * windE + windN * windN);
     *windDirection = atan2(-windE, -windN) / PI * 180;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -244,11 +244,15 @@ void MainWindow::initDatabase()
         }
     }
 
-    // Add new columns
+    // Add exit, ground and course
     QSqlQuery query(mDatabase);
     query.exec("alter table files add column exit text");
     query.exec("alter table files add column ground real");
     query.exec("alter table files add column course real");
+
+    // Add wind speed and direction
+    query.exec("alter table files add column wind_speed real");
+    query.exec("alter table files add column wind_dir real");
 }
 
 void MainWindow::initPlot()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -156,6 +156,11 @@ MainWindow::MainWindow(
     zoomTimer->setSingleShot(true);
 
     connect(zoomTimer, SIGNAL(timeout()), this, SLOT(saveZoom()));
+
+    // Disable zoom undo/redo controls
+    m_ui->actionUndoZoom->setEnabled(false);
+    m_ui->actionRedoZoom->setEnabled(false);
+    m_ui->actionZoomToExtent->setEnabled(false);
 }
 
 MainWindow::~MainWindow()
@@ -1408,9 +1413,12 @@ void MainWindow::initRange(
 
     emit dataChanged();
 
-    // Enable controls
+    // Disable undo/redo zoom controls
     m_ui->actionUndoZoom->setEnabled(false);
     m_ui->actionRedoZoom->setEnabled(false);
+
+    // Enable zoom to extent
+    m_ui->actionZoomToExtent->setEnabled(!m_data.isEmpty());
 }
 
 void MainWindow::on_actionElevation_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2094,6 +2094,8 @@ void MainWindow::saveZoom()
     setDatabaseValue(mTrackName, "t_min", dateTimeToUTC(dp.dateTime));
     dp = interpolateDataT(mZoomLevel.rangeUpper);
     setDatabaseValue(mTrackName, "t_max", dateTimeToUTC(dp.dateTime));
+
+    emit databaseChanged();
 }
 
 void MainWindow::setRotation(

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2154,7 +2154,7 @@ void MainWindow::closeReference()
 }
 
 void MainWindow::setOptimal(
-        const QVector< DataPoint > &result)
+        const DataPoints &result)
 {
     m_optimal = result;
     emit dataChanged();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -248,7 +248,7 @@ void MainWindow::initDatabase()
     QSqlQuery query(mDatabase);
     query.exec("alter table files add column exit text");
     query.exec("alter table files add column ground real");
-    query.exec("alter table files add column course text");
+    query.exec("alter table files add column course real");
 }
 
 void MainWindow::initPlot()
@@ -2022,7 +2022,7 @@ void MainWindow::setCourse(
     if (m_data.isEmpty()) return;
 
     DataPoint dp0 = interpolateDataT(t);
-    setDatabaseValue("course", dp0.dateTime.toString("yyyy-MM-dd HH:mm:ss.zzz"));
+    setDatabaseValue("course", QString::number(dp0.heading, 'f', 5));
 
     for (int i = 0; i < m_data.size(); ++i)
     {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2111,9 +2111,9 @@ bool MainWindow::setDatabaseValue(
 {
     QSqlQuery query(mDatabase);
 
-    // Get the old value
-    if (!query.exec(QString("select %1 from files where file_name='%2'")
-                    .arg(column).arg(trackName)))
+    // Check the old value
+    if (!query.exec(QString("select %1 from files where (file_name='%2' and %3='%4')")
+                    .arg(column).arg(trackName).arg(column).arg(value)))
     {
         QSqlError err = query.lastError();
         QMessageBox::critical(0, tr("Query failed"), err.text());
@@ -2121,7 +2121,7 @@ bool MainWindow::setDatabaseValue(
     }
 
     // Return now if value is not changed
-    if (query.next() && value == query.value(0).toString()) return true;
+    if (query.next()) return true;
 
     // Change the value
     if (!query.exec(QString("update files set %1='%2' where file_name='%3'")

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2129,6 +2129,58 @@ void MainWindow::setTrackGround(
     }
 }
 
+void MainWindow::setTrackWindSpeed(
+        QString trackName,
+        double windSpeed)
+{
+    setDatabaseValue(trackName, "wind_speed", QString::number(windSpeed, 'f', 2));
+
+    // Update current track
+    if (trackName == mTrackName)
+    {
+        updateVelocity(m_data, mTrackName, false);
+        emit dataChanged();
+    }
+
+    // Update checked tracks
+    QMap< QString, DataPoints >::iterator p;
+    for (p = mCheckedTracks.begin();
+         p != mCheckedTracks.end();
+         ++p)
+    {
+        if (trackName == p.key())
+        {
+            updateVelocity(p.value(), p.key(), false);
+        }
+    }
+}
+
+void MainWindow::setTrackWindDir(
+        QString trackName,
+        double windDir)
+{
+    setDatabaseValue(trackName, "wind_dir", QString::number(windDir, 'f', 5));
+
+    // Update current track
+    if (trackName == mTrackName)
+    {
+        updateVelocity(m_data, mTrackName, false);
+        emit dataChanged();
+    }
+
+    // Update checked tracks
+    QMap< QString, DataPoints >::iterator p;
+    for (p = mCheckedTracks.begin();
+         p != mCheckedTracks.end();
+         ++p)
+    {
+        if (trackName == p.key())
+        {
+            updateVelocity(p.value(), p.key(), false);
+        }
+    }
+}
+
 void MainWindow::updateGround(
         DataPoints &data,
         double ground)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2106,12 +2106,7 @@ void MainWindow::saveZoom()
     m_ui->actionRedoZoom->setEnabled(!mZoomLevelRedo.empty());
 
     // Save zoom level to database
-    DataPoint dp = interpolateDataT(mZoomLevel.rangeLower);
-    setDatabaseValue(mTrackName, "t_min", dateTimeToUTC(dp.dateTime));
-    dp = interpolateDataT(mZoomLevel.rangeUpper);
-    setDatabaseValue(mTrackName, "t_max", dateTimeToUTC(dp.dateTime));
-
-    emit databaseChanged();
+    saveZoomToDatabase();
 }
 
 void MainWindow::setRotation(
@@ -2489,6 +2484,9 @@ void MainWindow::on_actionUndoZoom_triggered()
     // Enable controls
     m_ui->actionUndoZoom->setEnabled(!mZoomLevelUndo.empty());
     m_ui->actionRedoZoom->setEnabled(!mZoomLevelRedo.empty());
+
+    // Save zoom level to database
+    saveZoomToDatabase();
 }
 
 void MainWindow::on_actionRedoZoom_triggered()
@@ -2501,6 +2499,19 @@ void MainWindow::on_actionRedoZoom_triggered()
     // Enable controls
     m_ui->actionUndoZoom->setEnabled(!mZoomLevelUndo.empty());
     m_ui->actionRedoZoom->setEnabled(!mZoomLevelRedo.empty());
+
+    // Save zoom level to database
+    saveZoomToDatabase();
+}
+
+void MainWindow::saveZoomToDatabase()
+{
+    DataPoint dp = interpolateDataT(mZoomLevel.rangeLower);
+    setDatabaseValue(mTrackName, "t_min", dateTimeToUTC(dp.dateTime));
+    dp = interpolateDataT(mZoomLevel.rangeUpper);
+    setDatabaseValue(mTrackName, "t_max", dateTimeToUTC(dp.dateTime));
+
+    emit databaseChanged();
 }
 
 void MainWindow::on_actionZoomToExtent_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -243,6 +243,12 @@ void MainWindow::initDatabase()
             QMessageBox::critical(0, tr("Query failed"), err.text());
         }
     }
+
+    // Add new columns
+    QSqlQuery query(mDatabase);
+    query.exec("alter table files add column exit text");
+    query.exec("alter table files add column ground real");
+    query.exec("alter table files add column course text");
 }
 
 void MainWindow::initPlot()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -138,6 +138,7 @@ public:
     void closeReference();
 
     void importFromDatabase(const QString &uniqueName);
+    void importFromCheckedTrack(const QString &uniqueName);
 
     void setTrackName(const QString &trackName);
     QString trackName() const { return mTrackName; }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,8 +125,8 @@ public:
     double lineThickness() const { return mLineThickness; }
 
     void setWind(double windE, double windN);
-    void getWind(double *windE, double *windN);
-    void getWindSpeedDirection(double *windSpeed, double *windDirection);
+    void getWind(QString trackName, double *windE, double *windN);
+    void getWindSpeedDirection(QString trackName, double *windSpeed, double *windDirection);
     bool windAdjustment() const { return mWindAdjustment; }
 
     double getQNE(void) const { return mFixedReference;}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -67,6 +67,8 @@ public:
     void setCourse(double t);
 
     void setTrackGround(QString trackName, double ground);
+    void setTrackWindSpeed(QString trackName, double windSpeed);
+    void setTrackWindDir(QString trackName, double windDIr);
 
     void setTool(Tool tool);
     Tool tool() const { return mTool; }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,7 +125,6 @@ public:
     double lineThickness() const { return mLineThickness; }
 
     void setWind(double windE, double windN);
-    void getWind(double *windE, double *windN);
     void getWindSpeedDirection(double *windSpeed, double *windDirection);
     bool windAdjustment() const { return mWindAdjustment; }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -231,6 +231,7 @@ private:
     Tool                  mPrevTool;
 
     ZoomLevel             mZoomLevel;
+    ZoomLevel             mZoomLevelPrev;
     QStack< ZoomLevel >   mZoomLevelUndo;
     QStack< ZoomLevel >   mZoomLevelRedo;
 
@@ -268,6 +269,8 @@ private:
     QString               mTrackName;
     QVector< QString >    mSelectedTracks;
     QMap< QString, DataPoints > mCheckedTracks;
+
+    QTimer               *zoomTimer;
 
     void writeSettings();
     void readSettings();
@@ -319,6 +322,7 @@ public slots:
 
 private slots:
     void setScoringVisible(bool visible);
+    void saveZoom();
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QLabel>
 #include <QMainWindow>
+#include <QMap>
 #include <QSqlDatabase>
 #include <QStack>
 #include <QVector>
@@ -144,6 +145,9 @@ public:
     void setSelectedTracks(QVector< QString > tracks);
     void setTrackDescription(const QString &trackName, const QString &description);
 
+    void setTrackChecked(const QString &trackName, bool checked);
+    bool trackChecked(const QString &trackName) const;
+
     QString databasePath() const { return mDatabasePath; }
 
 protected:
@@ -258,6 +262,7 @@ private:
 
     QString               mTrackName;
     QVector< QString >    mSelectedTracks;
+    QSet< QString >       mCheckedTracks;
 
     void writeSettings();
     void readSettings();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,6 +125,7 @@ public:
     double lineThickness() const { return mLineThickness; }
 
     void setWind(double windE, double windN);
+    void getWind(double *windE, double *windN);
     void getWindSpeedDirection(double *windSpeed, double *windDirection);
     bool windAdjustment() const { return mWindAdjustment; }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -262,7 +262,7 @@ private:
 
     QString               mTrackName;
     QVector< QString >    mSelectedTracks;
-    QSet< QString >       mCheckedTracks;
+    QMap< QString, DataPoints > mCheckedTracks;
 
     void writeSettings();
     void readSettings();
@@ -282,10 +282,10 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
-    void import(QIODevice *device);
-    void initAltitude();
-    void updateVelocity();
-    void initAerodynamics();
+    void import(QIODevice *device, DataPoints &data);
+    void initAltitude(DataPoints &data);
+    void updateVelocity(DataPoints &data);
+    void initAerodynamics(DataPoints &data);
 
     double getSlope(const int center, double (*value)(const DataPoint &)) const;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -58,7 +58,7 @@ public:
 
     PlotValue::Units units() const { return m_units; }
 
-    void setRange(double lower, double upper);
+    void setRange(double lower, double upper, bool immediate = false);
     double rangeLower() const { return mZoomLevel.rangeLower; }
     double rangeUpper() const { return mZoomLevel.rangeUpper; }
 
@@ -204,6 +204,7 @@ private slots:
 
     void on_actionUndoZoom_triggered();
     void on_actionRedoZoom_triggered();
+    void on_actionZoomToExtent_triggered();
 
     void on_actionDeleteTrack_triggered();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -301,6 +301,7 @@ private:
     void updateLeftActions();
 
     void updateGround(DataPoints &data, double ground);
+    QString dateTimeToUTC(const QDateTime &dt);
 
 signals:
     void dataLoaded();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -269,7 +269,8 @@ private:
     void readSettings();
 
     void initDatabase();
-    bool setDatabaseValue(QString column, QString value);
+    bool setDatabaseValue(QString trackName, QString column, QString value);
+    bool getDatabaseValue(QString trackName, QString column, QString &value);
 
     void initPlot();
     void initViews();
@@ -284,10 +285,10 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
-    void import(QIODevice *device, DataPoints &data);
-    void initTime(DataPoints &data);
-    void initAltitude(DataPoints &data);
-    void updateVelocity(DataPoints &data);
+    void import(QIODevice *device, DataPoints &data, QString trackName);
+    void initTime(DataPoints &data, QString trackName);
+    void initAltitude(DataPoints &data, QString trackName);
+    void updateVelocity(DataPoints &data, QString trackName);
     void initAerodynamics(DataPoints &data);
 
     double getSlope(const int center, double (*value)(const DataPoint &)) const;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -300,7 +300,7 @@ private:
 
     double getSlope(const int center, double (*value)(const DataPoint &)) const;
 
-    void initRange();
+    void initRange(QString trackName);
 
     void updateBottomActions();
     void updateLeftActions();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -279,6 +279,7 @@ private:
     void initDatabase();
     bool setDatabaseValue(QString trackName, QString column, QString value);
     bool getDatabaseValue(QString trackName, QString column, QString &value);
+    void saveZoomToDatabase();
 
     void initPlot();
     void initViews();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -47,10 +47,12 @@ public:
         Automatic, Fixed
     } GroundReference;
 
+    typedef QVector< DataPoint > DataPoints;
+
     explicit MainWindow(QWidget *parent = 0);
     ~MainWindow();
 
-    const QVector< DataPoint > &data() const { return m_data; }
+    const DataPoints &data() const { return m_data; }
     int dataSize() const { return m_data.size(); }
     const DataPoint &dataPoint(int i) const { return m_data[i]; }
 
@@ -107,8 +109,8 @@ public:
     void setMaxLift(double maxLift);
     void setMaxLD(double maxLD);    
 
-    const QVector< DataPoint > &optimal() const { return m_optimal; }
-    void setOptimal(const QVector< DataPoint > &result);
+    const DataPoints &optimal() const { return m_optimal; }
+    void setOptimal(const DataPoints &result);
 
     int optimalSize() const { return m_optimal.size(); }
     const DataPoint &optimalPoint(int i) const { return m_optimal[i]; }
@@ -128,8 +130,6 @@ public:
     void setScoringMode(ScoringMode mode);
     ScoringMode scoringMode() const { return mScoringMode; }
     ScoringMethod *scoringMethod(int i) const { return mScoringMethods[i]; }
-
-    bool getWindowBounds(const QVector< DataPoint > result, DataPoint &dpBottom, DataPoint &dpTop);
 
     void prepareDataPlot(DataPlot *plot);
     void prepareMapView(MapView *plot);
@@ -209,8 +209,8 @@ private:
     } ZoomLevel;
 
     Ui::MainWindow       *m_ui;
-    QVector< DataPoint >  m_data;
-    QVector< DataPoint >  m_optimal;
+    DataPoints            m_data;
+    DataPoints            m_optimal;
 
     double                mMarkStart;
     double                mMarkEnd;
@@ -220,7 +220,7 @@ private:
 
     PlotValue::Units      m_units;
 
-    QVector< DataPoint >  m_waypoints;
+    DataPoints            m_waypoints;
 
     Tool                  mTool;
     Tool                  mPrevTool;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -287,10 +287,10 @@ private:
     void initSingleView(const QString &title, const QString &objectName,
                         QAction *actionShow, DataView::Direction direction);
 
-    void import(QIODevice *device, DataPoints &data, QString trackName);
-    void initTime(DataPoints &data, QString trackName);
-    void initAltitude(DataPoints &data, QString trackName);
-    void updateVelocity(DataPoints &data, QString trackName);
+    void import(QIODevice *device, DataPoints &data, QString trackName, bool initDatabase);
+    void initTime(DataPoints &data, QString trackName, bool initDatabase);
+    void initAltitude(DataPoints &data, QString trackName, bool initDatabase);
+    void updateVelocity(DataPoints &data, QString trackName, bool initDatabase);
     void initAerodynamics(DataPoints &data);
 
     double getSlope(const int center, double (*value)(const DataPoint &)) const;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -269,6 +269,7 @@ private:
     void readSettings();
 
     void initDatabase();
+    bool setDatabaseValue(QString column, QString value);
 
     void initPlot();
     void initViews();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -285,6 +285,7 @@ private:
                         QAction *actionShow, DataView::Direction direction);
 
     void import(QIODevice *device, DataPoints &data);
+    void initTime(DataPoints &data);
     void initAltitude(DataPoints &data);
     void updateVelocity(DataPoints &data);
     void initAerodynamics(DataPoints &data);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -66,6 +66,8 @@ public:
     void setGround(double t);
     void setCourse(double t);
 
+    void setTrackGround(QString trackName, double ground);
+
     void setTool(Tool tool);
     Tool tool() const { return mTool; }
 
@@ -297,6 +299,8 @@ private:
 
     void updateBottomActions();
     void updateLeftActions();
+
+    void updateGround(DataPoints &data, double ground);
 
 signals:
     void dataLoaded();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -38,7 +38,7 @@
      <x>0</x>
      <y>0</y>
      <width>600</width>
-     <height>21</height>
+     <height>17</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -104,6 +104,7 @@
     </property>
     <addaction name="actionUndoZoom"/>
     <addaction name="actionRedoZoom"/>
+    <addaction name="actionZoomToExtent"/>
     <addaction name="separator"/>
     <addaction name="actionPan"/>
     <addaction name="actionZoom"/>
@@ -691,6 +692,14 @@
   <action name="actionImportFolder">
    <property name="text">
     <string>Import Folder...</string>
+   </property>
+  </action>
+  <action name="actionZoomToExtent">
+   <property name="text">
+    <string>Zoom To Extent</string>
+   </property>
+   <property name="shortcut">
+    <string>Shift+Z</string>
    </property>
   </action>
  </widget>

--- a/src/ppcscoring.cpp
+++ b/src/ppcscoring.cpp
@@ -30,7 +30,7 @@ void PPCScoring::setWindow(
 }
 
 double PPCScoring::score(
-        const QVector< DataPoint > &result)
+        const MainWindow::DataPoints &result)
 {
     DataPoint dpBottom, dpTop;
     if (getWindowBounds(result, dpBottom, dpTop))
@@ -152,7 +152,7 @@ void PPCScoring::prepareDataPlot(
 }
 
 bool PPCScoring::getWindowBounds(
-        const QVector< DataPoint > &result,
+        const MainWindow::DataPoints &result,
         DataPoint &dpBottom,
         DataPoint &dpTop)
 {

--- a/src/ppcscoring.h
+++ b/src/ppcscoring.h
@@ -21,12 +21,12 @@ public:
     double windowBottom(void) const { return mWindowBottom; }
     void setWindow(double windowBottom, double windowTop);
 
-    double score(const QVector< DataPoint > &result);
+    double score(const MainWindow::DataPoints &result);
     QString scoreAsText(double score);
 
     void prepareDataPlot(DataPlot *plot);
 
-    bool getWindowBounds(const QVector< DataPoint > &result,
+    bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom, DataPoint &dpTop);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }

--- a/src/ppcupload.cpp
+++ b/src/ppcupload.cpp
@@ -48,7 +48,7 @@ void PPCUpload::upload(const QString type, const double windowTop, const double 
     profile["times"] = times;
 
     double windSpeed, windDirection;
-    mMainWindow->getWindSpeedDirection(&windSpeed, &windDirection);
+    mMainWindow->getWindSpeedDirection(mMainWindow->trackName(), &windSpeed, &windDirection);
 
     QString name, countrycode, equipment, place;
     if (!getUserDetails(&name, &countrycode, !type.compare("WS"), &equipment, &place)) {

--- a/src/scoringmethod.cpp
+++ b/src/scoringmethod.cpp
@@ -64,7 +64,7 @@ void ScoringMethod::optimize(
         }
 
         Genome g(genomeSize, kMin, mainWindow->minLift(), mainWindow->maxLift());
-        const QVector< DataPoint > result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
+        const MainWindow::DataPoints result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
         const double s = score(result);
         genePool.append(Score(s, g));
 
@@ -108,7 +108,7 @@ void ScoringMethod::optimize(
                 }
 
                 Genome g(genomeSize, kMin, mainWindow->minLift(), mainWindow->maxLift());
-                const QVector< DataPoint > result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
+                const MainWindow::DataPoints result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
                 const double s = score(result);
                 newGenePool.append(Score(s, g));
 
@@ -138,7 +138,7 @@ void ScoringMethod::optimize(
                     g.mutate(k, kMin, mainWindow->minLift(), mainWindow->maxLift());
                 }
 
-                const QVector< DataPoint > result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
+                const MainWindow::DataPoints result = g.simulate(dt, a, c, mainWindow->planformArea(), mainWindow->mass(), dp0, windowBottom);
                 const double s = score(result);
                 newGenePool.append(Score(s, g));
 

--- a/src/scoringmethod.h
+++ b/src/scoringmethod.h
@@ -26,7 +26,7 @@ class ScoringMethod : public QObject
 public:
     explicit ScoringMethod(QObject *parent = 0);
 
-    virtual double score(const QVector< DataPoint > &result) { return 0; }
+    virtual double score(const MainWindow::DataPoints &result) { return 0; }
     virtual QString scoreAsText(double score) { return QString(); }
 
     virtual void prepareDataPlot(DataPlot *plot) {}

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -22,7 +22,7 @@ void SpeedScoring::setWindow(
 }
 
 double SpeedScoring::score(
-        const QVector< DataPoint > &result)
+        const MainWindow::DataPoints &result)
 {
     DataPoint dpBottom, dpTop;
     if (getWindowBounds(result, dpBottom, dpTop))
@@ -126,7 +126,7 @@ void SpeedScoring::prepareDataPlot(
 }
 
 bool SpeedScoring::getWindowBounds(
-        const QVector< DataPoint > &result,
+        const MainWindow::DataPoints &result,
         DataPoint &dpBottom,
         DataPoint &dpTop)
 {

--- a/src/speedscoring.h
+++ b/src/speedscoring.h
@@ -14,12 +14,12 @@ public:
     double windowBottom(void) const { return mWindowBottom; }
     void setWindow(double windowBottom, double windowTop);
 
-    double score(const QVector< DataPoint > &result);
+    double score(const MainWindow::DataPoints &result);
     QString scoreAsText(double score);
 
     void prepareDataPlot(DataPlot *plot);
 
-    bool getWindowBounds(const QVector< DataPoint > &result,
+    bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom, DataPoint &dpTop);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }

--- a/src/wideopendistancescoring.cpp
+++ b/src/wideopendistancescoring.cpp
@@ -472,7 +472,7 @@ void WideOpenDistanceScoring::splitLine(
 }
 
 bool WideOpenDistanceScoring::getWindowBounds(
-        const QVector< DataPoint > &result,
+        const MainWindow::DataPoints &result,
         DataPoint &dpBottom)
 {
     bool foundBottom = false;

--- a/src/wideopendistancescoring.h
+++ b/src/wideopendistancescoring.h
@@ -38,7 +38,7 @@ public:
     bool updateReference(double lat, double lon);
     void closeReference();
 
-    bool getWindowBounds(const QVector< DataPoint > &result,
+    bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom);
 
     void readSettings();

--- a/src/wideopenspeedscoring.cpp
+++ b/src/wideopenspeedscoring.cpp
@@ -369,7 +369,7 @@ void WideOpenSpeedScoring::splitLine(
 }
 
 bool WideOpenSpeedScoring::getWindowBounds(
-        const QVector< DataPoint > &result,
+        const MainWindow::DataPoints &result,
         DataPoint &dpBottom)
 {
     bool foundBottom = false;

--- a/src/wideopenspeedscoring.h
+++ b/src/wideopenspeedscoring.h
@@ -38,7 +38,7 @@ public:
     bool updateReference(double lat, double lon);
     void closeReference();
 
-    bool getWindowBounds(const QVector< DataPoint > &result,
+    bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom);
 
     void readSettings();


### PR DESCRIPTION
This branch adds several new columns to the FlySight database to store exit time, ground elevation, course heading, wind velocity and display range.

In addition, we have moved the ground elevation settings previously in the "General" tab to a new "Import" tab. The first time a track is imported, these settings will be used to establish the initial ground elevation. Subsequently, ground elevation will be loaded from the database. Ground elevation can be modified by changing its value in the logbook view.

Wind speed can be set either using the wind tool or by manually editing in the logbook view.

Finally, the database also stores the current display range. We've added a 1-second delay when zooming in/out so that only views where the user pauses for one second will be added to the undo/redo stack or stored to the database. We've also added a "zoom to extent" menu option which brings the view back to the full extent of the data.