### PR TITLE
Toggle units with a hotkey

### DIFF
--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -7,7 +7,8 @@ DataPlot::DataPlot(QWidget *parent) :
     QCustomPlot(parent),
     mMainWindow(0),
     m_dragging(false),
-    m_xAxisType(Time)
+    m_xAxisType(Time),
+    m_cursorValid(false)
 {
     // Initialize window
     setMouseTracking(true);
@@ -103,7 +104,8 @@ void DataPlot::mousePressEvent(
 {
     if (axisRect()->rect().contains(event->pos()))
     {
-        m_beginPos = event->pos();
+        m_xBegin = event->pos().x();
+        m_yBegin = event->pos().y();
         m_dragging = true;
         update();
     }
@@ -119,9 +121,9 @@ void DataPlot::mouseReleaseEvent(
     MainWindow::Tool tool = mMainWindow->tool();
     if (m_dragging && tool == MainWindow::Zoom)
     {
-        QCPRange range(qMin(xAxis->pixelToCoord(m_beginPos.x()),
+        QCPRange range(qMin(xAxis->pixelToCoord(m_xBegin),
                             xAxis->pixelToCoord(endPos.x())),
-                       qMax(xAxis->pixelToCoord(m_beginPos.x()),
+                       qMax(xAxis->pixelToCoord(m_xBegin),
                             xAxis->pixelToCoord(endPos.x())));
 
         setRange(range);
@@ -154,32 +156,35 @@ void DataPlot::mouseReleaseEvent(
 void DataPlot::mouseMoveEvent(
         QMouseEvent *event)
 {
-    m_cursorPos = event->pos();
+    m_xCursor = event->pos().x();
+    m_yCursor = event->pos().y();
+    m_cursorValid = true;
 
     MainWindow::Tool tool = mMainWindow->tool();
     if (m_dragging && tool == MainWindow::Pan)
     {
         QCPRange range = xAxis->range();
 
-        double diff = xAxis->pixelToCoord(m_beginPos.x())
-                - xAxis->pixelToCoord(m_cursorPos.x());
+        double diff = xAxis->pixelToCoord(m_xBegin)
+                - xAxis->pixelToCoord(m_xCursor);
         range = QCPRange(range.lower + diff, range.upper + diff);
 
         setRange(range);
 
-        m_beginPos = m_cursorPos;
+        m_xBegin = m_xCursor;
+        m_yBegin = m_yCursor;
     }
 
     if (axisRect()->rect().contains(event->pos()))
     {
         if (m_dragging && tool == MainWindow::Measure)
         {
-            setMark(xAxis->pixelToCoord(m_beginPos.x()),
-                    xAxis->pixelToCoord(m_cursorPos.x()));
+            setMark(xAxis->pixelToCoord(m_xBegin),
+                    xAxis->pixelToCoord(m_xCursor));
         }
         else
         {
-            setMark(xAxis->pixelToCoord(m_cursorPos.x()));
+            setMark(xAxis->pixelToCoord(m_xCursor));
         }
     }
     else
@@ -216,7 +221,7 @@ void DataPlot::leaveEvent(
         QEvent *)
 {
     mMainWindow->clearMark();
-    m_cursorPos = QPoint();
+    m_cursorValid = false;
     update();
 }
 
@@ -225,35 +230,37 @@ void DataPlot::paintEvent(
 {
     QCustomPlot::paintEvent(event);
 
+    if (!m_cursorValid) return;
+
     MainWindow::Tool tool = mMainWindow->tool();
     if (m_dragging && (tool == MainWindow::Zoom || tool == MainWindow::Measure))
     {
         QPainter painter(this);
 
         painter.setPen(QPen(Qt::black));
-        painter.drawLine(m_beginPos.x(), axisRect()->rect().top(), m_beginPos.x(), axisRect()->rect().bottom());
-        if (axisRect()->rect().left() <= m_cursorPos.x() && m_cursorPos.x() <= axisRect()->rect().right())
+        painter.drawLine(m_xBegin, axisRect()->rect().top(), m_xBegin, axisRect()->rect().bottom());
+        if (axisRect()->rect().left() <= m_xCursor && m_yCursor <= axisRect()->rect().right())
         {
-            painter.drawLine(m_cursorPos.x(), axisRect()->rect().top(), m_cursorPos.x(), axisRect()->rect().bottom());
+            painter.drawLine(m_xCursor, axisRect()->rect().top(), m_xCursor, axisRect()->rect().bottom());
         }
 
         QRect shading(
-                    qMin(m_beginPos.x(), m_cursorPos.x()),
+                    qMin(m_xBegin, m_xCursor),
                     axisRect()->rect().top(),
-                    qAbs(m_beginPos.x() - m_cursorPos.x()),
+                    qAbs(m_xBegin - m_xCursor),
                     axisRect()->rect().height());
 
         painter.fillRect(shading & axisRect()->rect(), QColor(181, 217, 42, 64));
     }
     else
     {
-        if (axisRect()->rect().contains(m_cursorPos))
+        if (axisRect()->rect().contains(m_xCursor, m_yCursor))
         {
             QPainter painter(this);
 
             painter.setPen(QPen(Qt::black));
-            painter.drawLine(m_cursorPos.x(), axisRect()->rect().top(), m_cursorPos.x(), axisRect()->rect().bottom());
-            painter.drawLine(axisRect()->rect().left(), m_cursorPos.y(), axisRect()->rect().right(), m_cursorPos.y());
+            painter.drawLine(m_xCursor, axisRect()->rect().top(), m_xCursor, axisRect()->rect().bottom());
+            painter.drawLine(axisRect()->rect().left(), m_yCursor, axisRect()->rect().right(), m_yCursor);
         }
     }
 }

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -178,11 +178,14 @@ void DataPlot::mouseMoveEvent(
     {
         if (m_dragging && tool == MainWindow::Measure)
         {
-            setMark(m_tBegin, m_tCursor);
+            DataPoint dpStart = interpolateDataX(m_tBegin);
+            DataPoint dpEnd = interpolateDataX(m_tCursor);
+            mMainWindow->setMark(dpStart.t, dpEnd.t);
         }
         else
         {
-            setMark(m_tCursor);
+            DataPoint dp = interpolateDataX(m_tCursor);
+            mMainWindow->setMark(dp.t);
         }
     }
     else
@@ -273,8 +276,6 @@ void DataPlot::setMark(
 {
     DataPoint dpStart = interpolateDataX(start);
     DataPoint dpEnd = interpolateDataX(end);
-
-    mMainWindow->setMark(dpStart.t, dpEnd.t);
 
     if (mMainWindow->dataSize() == 0) return;
 
@@ -413,7 +414,6 @@ void DataPlot::setMark(
     if (mMainWindow->dataSize() == 0) return;
 
     DataPoint dp = interpolateDataX(mark);
-    mMainWindow->setMark(dp.t);
 
     QString status;
     status = QString("<table width='300'>");
@@ -678,6 +678,25 @@ void DataPlot::updateCursor()
 
             m_cursors.push_back(graph);
         }
+    }
+
+    double xCursor = xAxis->coordToPixel(m_tCursor);
+
+    MainWindow::Tool tool = mMainWindow->tool();
+    if (axisRect()->rect().contains(xCursor, m_yCursor))
+    {
+        if (m_dragging && tool == MainWindow::Measure)
+        {
+            setMark(m_tBegin, m_tCursor);
+        }
+        else
+        {
+            setMark(m_tCursor);
+        }
+    }
+    else
+    {
+        QToolTip::hideText();
     }
 
     replot();

--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -758,10 +758,16 @@ void DataPlot::setXAxisType(
     DataPoint dpLower = interpolateDataX(range.lower);
     DataPoint dpUpper = interpolateDataX(range.upper);
 
+    DataPoint dpCursor = interpolateDataX(m_tCursor);
+    DataPoint dpBegin = interpolateDataX(m_tBegin);
+
     m_xAxisType = xAxisType;
 
     xAxis->setRange(QCPRange(xValue()->value(dpLower, mMainWindow->units()),
                              xValue()->value(dpUpper, mMainWindow->units())));
+
+    m_tCursor = xValue()->value(dpCursor, mMainWindow->units());
+    m_tBegin = xValue()->value(dpBegin, mMainWindow->units());
 
     updatePlot();
 }

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -67,8 +67,8 @@ protected:
     void paintEvent(QPaintEvent *event);
 
 private:
-    int m_xCursor, m_yCursor;
-    int m_xBegin, m_yBegin;
+    double m_tCursor, m_tBegin;
+    int m_yCursor, m_yBegin;
     bool m_cursorValid;
 
     bool m_dragging;

--- a/src/dataplot.h
+++ b/src/dataplot.h
@@ -67,8 +67,9 @@ protected:
     void paintEvent(QPaintEvent *event);
 
 private:
-    QPoint m_cursorPos;
-    QPoint m_beginPos;
+    int m_xCursor, m_yCursor;
+    int m_xBegin, m_yBegin;
+    bool m_cursorValid;
 
     bool m_dragging;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2574,6 +2574,21 @@ void MainWindow::on_actionDeleteTrack_triggered()
     emit databaseChanged();
 }
 
+void MainWindow::on_actionChangeUnits_triggered()
+{
+    switch (m_units)
+    {
+    case PlotValue::Metric:
+        m_units = PlotValue::Imperial;
+        break;
+    case PlotValue::Imperial:
+        m_units = PlotValue::Metric;
+        break;
+    }
+
+    emit dataChanged();
+}
+
 void MainWindow::setScoringMode(
         ScoringMode mode)
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -208,6 +208,8 @@ private slots:
 
     void on_actionDeleteTrack_triggered();
 
+    void on_actionChangeUnits_triggered();
+
 private:
     typedef struct {
         double rangeLower;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -115,6 +115,7 @@
     <addaction name="actionSetCourse"/>
     <addaction name="separator"/>
     <addaction name="actionWind"/>
+    <addaction name="actionChangeUnits"/>
    </widget>
    <widget class="QMenu" name="menuWindow">
     <property name="title">
@@ -700,6 +701,14 @@
    </property>
    <property name="shortcut">
     <string>Shift+Z</string>
+   </property>
+  </action>
+  <action name="actionChangeUnits">
+   <property name="text">
+    <string>Change &amp;Units</string>
+   </property>
+   <property name="shortcut">
+    <string>U</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This pull request adds the ability to toggle between metric and imperial units using a hotkey (u). When units are toggled, all displays and the tooltip will be updated, but the cursor itself will not move.