### PR TITLE
Fix error resulting in segfault

### DIFF
--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -640,7 +640,7 @@ void DataPlot::updateCursor()
         {
             removePlottable((QCPAbstractPlottable*) l);
         }
-        if (qobject_cast<QCPAbstractItem*>(l))
+        else if (qobject_cast<QCPAbstractItem*>(l))
         {
             removeItem((QCPAbstractItem*) l);
         }


### PR DESCRIPTION
Fixed a problem which resulted in segfault on Mac. We were inadvertently casting an invalid pointer if the first condition was true.