### PR TITLE
Move Google Maps API key and omit from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build*/
 
 # Mac files
 .DS_Store
+
+# Header file with keys
+secrets.h

--- a/src/mapview.cpp
+++ b/src/mapview.cpp
@@ -23,19 +23,27 @@
 
 #include "mapview.h"
 
+#include <QFile>
 #include <QVector>
 #include <QWebFrame>
 #include <QWebElement>
 
 #include "common.h"
 #include "mainwindow.h"
+#include "secrets.h"
 
 MapView::MapView(QWidget *parent) :
     QWebView(parent),
     mMainWindow(0),
     mDragging(false)
 {
-    setUrl(QUrl("qrc:/html/mapview.html"));
+    QFile file(":/html/mapview.html");
+    if (file.open(QIODevice::ReadOnly))
+    {
+        QString html = file.readAll();
+        html.replace("GOOGLE_MAPS_API_KEY", GOOGLE_MAPS_API_KEY);
+        setHtml(html);
+    }
 }
 
 QSize MapView::sizeHint() const

--- a/src/mapview.html
+++ b/src/mapview.html
@@ -8,7 +8,7 @@
             #map-canvas { height: 100% }
         </style>
         <script type="text/javascript"
-            src="http://maps.googleapis.com/maps/api/js?key=AIzaSyAg0VNcAT9nkxAn4MZrGQvbRG-XIcX5GeE&sensor=false">
+            src="http://maps.googleapis.com/maps/api/js?key=GOOGLE_MAPS_API_KEY&sensor=false">
         </script>
         <script type="text/javascript">
             var poly;


### PR DESCRIPTION
This change makes the Google Maps API key private, since Google is now charging for Maps API usage. The previous (public) key will also be retired.