### PR TITLE
dataplot: Fix segfault when no data is loaded

### DIFF
--- a/src/dataplot.cpp
+++ b/src/dataplot.cpp
@@ -207,6 +207,9 @@ void DataPlot::mouseMoveEvent(
         }
         else
         {
+            if (mMainWindow->dataSize() == 0)
+                return;
+
             DataPoint dp = interpolateDataX(m_tCursor);
             mMainWindow->setMark(dp.t);
         }


### PR DESCRIPTION
On some Ubuntu systems, FlysightViewer will segfault if
the mouse is moved over the main plot area while no tracks
are loaded. Prevent a segfault in DataPlot::mouseMoveEvent
by bailing out early if no data points are loaded.

Signed-off-by: evilwombat <evilwombat@server.fake>