### PR TITLE
Add algorithm for detecting exit

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1080,7 +1080,8 @@ void MainWindow::initExit(
             const DataPoint &dp2 = data[i];
 
             // Get interpolation coefficient
-            const double a = (A_GRAVITY - dp1.velD) / (dp2.velD - dp1.velD);
+            const double velD = A_GRAVITY;
+            const double a = (velD - dp1.velD) / (dp2.velD - dp1.velD);
 
             // Check vertical speed
             if (a < 0 || 1 < a) continue;
@@ -1091,12 +1092,12 @@ void MainWindow::initExit(
 
             // Check acceleration
             const double az = dp1.az + a * (dp2.az - dp1.az);
-            if (az < A_GRAVITY / 2) continue;
+            if (az < A_GRAVITY / 5.) continue;
 
             // Determine exit
             const qint64 t1 = dp1.dateTime.toMSecsSinceEpoch();
             const qint64 t2 = dp2.dateTime.toMSecsSinceEpoch();
-            start = t1 + a * (t2 - t1) - 1000.;
+            start = t1 + a * (t2 - t1) - velD / az * 1000.;
             foundExit = true;
         }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1047,7 +1047,7 @@ void MainWindow::import(
 void MainWindow::initTime(
         DataPoints &data)
 {
-    const DataPoint &dp0 = data[data.size() - 1];
+    const DataPoint &dp0 = data[0];
     qint64 start = dp0.dateTime.toMSecsSinceEpoch();
 
     for (int i = 0; i < data.size(); ++i)
@@ -1103,7 +1103,7 @@ void MainWindow::initExit(
 
         if (!foundExit)
         {
-            const DataPoint &dp0 = data[data.size() - 1];
+            const DataPoint &dp0 = data[0];
             start = dp0.dateTime.toMSecsSinceEpoch();
         }
     }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1029,7 +1029,7 @@ void MainWindow::import(
     }
 
     // Initialize time
-    initTime(data, trackName, initDatabase);
+    initTime(data);
 
     // Altitude above ground
     initAltitude(data, trackName, initDatabase);
@@ -1037,11 +1037,28 @@ void MainWindow::import(
     // Raw acceleration
     initAcceleration(data);
 
+    // Pick exit
+    initExit(data, trackName, initDatabase);
+
     // Wind adjustments
     updateVelocity(data, trackName, initDatabase);
 }
 
 void MainWindow::initTime(
+        DataPoints &data)
+{
+    const DataPoint &dp0 = data[data.size() - 1];
+    qint64 start = dp0.dateTime.toMSecsSinceEpoch();
+
+    for (int i = 0; i < data.size(); ++i)
+    {
+        DataPoint &dp = data[i];
+        qint64 end = dp.dateTime.toMSecsSinceEpoch();
+        dp.t = (double) (end - start) / 1000;
+    }
+}
+
+void MainWindow::initExit(
         DataPoints &data,
         QString trackName,
         bool initDatabase)
@@ -1055,8 +1072,33 @@ void MainWindow::initTime(
     }
     else
     {
-        const DataPoint &dp0 = data[data.size() - 1];
-        start = dp0.dateTime.toMSecsSinceEpoch();
+        bool foundExit = false;
+
+        for (int i = 1; i < data.size(); ++i)
+        {
+            const DataPoint &dp1 = data[i - 1];
+            const DataPoint &dp2 = data[i];
+
+            double a = (5 - dp1.az) / (dp2.az - dp1.az);
+            if (0 <= a && a < 1)
+            {
+                double vAcc = dp1.vAcc + a * (dp2.vAcc - dp1.vAcc);
+                if (vAcc < 10)
+                {
+                    foundExit = true;
+                    qint64 t1 = dp1.dateTime.toMSecsSinceEpoch();
+                    qint64 t2 = dp2.dateTime.toMSecsSinceEpoch();
+                    start = t1 + a * (t2 - t1);
+                    break;
+                }
+            }
+        }
+
+        if (!foundExit)
+        {
+            const DataPoint &dp0 = data[data.size() - 1];
+            start = dp0.dateTime.toMSecsSinceEpoch();
+        }
     }
 
     if (initDatabase)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -324,7 +324,8 @@ private:
                         QAction *actionShow, DataView::Direction direction);
 
     void import(QIODevice *device, DataPoints &data, QString trackName, bool initDatabase);
-    void initTime(DataPoints &data, QString trackName, bool initDatabase);
+    void initTime(DataPoints &data);
+    void initExit(DataPoints &data, QString trackName, bool initDatabase);
     void initAltitude(DataPoints &data, QString trackName, bool initDatabase);
     void initAcceleration(DataPoints &data);
     void updateVelocity(DataPoints &data, QString trackName, bool initDatabase);


### PR DESCRIPTION
This change adds an algorithm for detecting exit as follows:

1. Starting at the first point in the record, look for interpolated points where velD = 9.8 m/s.
2. Check that the point has vAcc < 10 m (i.e., we have a valid fix).
3. Check that the point has az > 0.2 g (i.e., we are in freefall).
4. Using az to extrapolate, find the point where velD would be 0 m/s. This is exit.
