### PR TITLE
Implement new scoring for Speed Skydiving

### DIFF
--- a/src/speedform.cpp
+++ b/src/speedform.cpp
@@ -42,7 +42,6 @@ SpeedForm::SpeedForm(QWidget *parent) :
     connect(ui->upButton, SIGNAL(clicked()), this, SLOT(onUpButtonClicked()));
     connect(ui->downButton, SIGNAL(clicked()), this, SLOT(onDownButtonClicked()));
 
-    connect(ui->topEdit, SIGNAL(editingFinished()), this, SLOT(onApplyButtonClicked()));
     connect(ui->bottomEdit, SIGNAL(editingFinished()), this, SLOT(onApplyButtonClicked()));
 
     // Connect optimization buttons
@@ -80,11 +79,9 @@ void SpeedForm::updateView()
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
 
     const double bottom = method->windowBottom();
-    const double top = method->windowTop();
 
     // Update window bounds
     ui->bottomEdit->setText(QString("%1").arg(bottom));
-    ui->topEdit->setText(QString("%1").arg(top));
 
     DataPoint dpBottom, dpTop;
     bool success;
@@ -103,7 +100,7 @@ void SpeedForm::updateView()
     {
         // Calculate results
         const double time = dpBottom.t - dpTop.t;
-        const double verticalSpeed = (top - bottom) / time;
+        const double verticalSpeed = (dpTop.z - dpBottom.z) / time;
 
         // Update display
         if (mMainWindow->units() == PlotValue::Metric)
@@ -144,16 +141,15 @@ void SpeedForm::updateView()
 void SpeedForm::onFAIButtonClicked()
 {
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
-    method->setWindow(1700, 2700);
+    method->setWindow(1700);
 }
 
 void SpeedForm::onApplyButtonClicked()
 {
     double bottom = ui->bottomEdit->text().toDouble();
-    double top = ui->topEdit->text().toDouble();
 
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
-    method->setWindow(bottom, top);
+    method->setWindow(bottom);
 
     mMainWindow->setFocus();
 }
@@ -161,13 +157,13 @@ void SpeedForm::onApplyButtonClicked()
 void SpeedForm::onUpButtonClicked()
 {
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
-    method->setWindow(method->windowBottom() + 10, method->windowTop() + 10);
+    method->setWindow(method->windowBottom() + 10);
 }
 
 void SpeedForm::onDownButtonClicked()
 {
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
-    method->setWindow(method->windowBottom() - 10, method->windowTop() - 10);
+    method->setWindow(method->windowBottom() - 10);
 }
 
 void SpeedForm::keyPressEvent(QKeyEvent *event)

--- a/src/speedform.ui
+++ b/src/speedform.ui
@@ -22,34 +22,17 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Top:</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="topEdit"/>
+         <widget class="QLineEdit" name="bottomEdit"/>
         </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="topUnits">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
+        <item row="0" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Bottom:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="bottomEdit"/>
-        </item>
-        <item row="1" column="2">
+        <item row="0" column="2">
          <widget class="QLabel" name="bottomUnits">
           <property name="text">
            <string>m</string>

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -29,18 +29,15 @@ SpeedScoring::SpeedScoring(
         MainWindow *mainWindow):
     ScoringMethod(mainWindow),
     mMainWindow(mainWindow),
-    mWindowTop(2700),
     mWindowBottom(1700)
 {
 
 }
 
 void SpeedScoring::setWindow(
-        double windowBottom,
-        double windowTop)
+        double windowBottom)
 {
     mWindowBottom = windowBottom;
-    mWindowTop = windowTop;
     emit scoringChanged();
 }
 
@@ -50,7 +47,7 @@ double SpeedScoring::score(
     DataPoint dpBottom, dpTop;
     if (getWindowBounds(result, dpBottom, dpTop))
     {
-        return (mWindowTop - mWindowBottom) / (dpBottom.t - dpTop.t);
+        return (dpTop.z - dpBottom.z) / (dpBottom.t - dpTop.t);
     }
 
     return 0;
@@ -151,50 +148,43 @@ bool SpeedScoring::getWindowBounds(
         DataPoint &dpBottom,
         DataPoint &dpTop)
 {
-    bool foundBottom = false;
-    bool foundTop = false;
-    int bottom, top;
+    bool found = false;
+    int i0 = result.size() - 1;
+    double maxScore = 0;
 
-    for (int i = result.size() - 1; i >= 0; --i)
+    for (int i3 = result.size() - 1; i3 >= 0; --i3)
     {
-        const DataPoint &dp = result[i];
+        const DataPoint &dp3 = result[i3];
+        const double t1 = dp3.t - 3;
 
-        if (dp.z < mWindowBottom)
+        for (; i0 >= 0; --i0)
         {
-            bottom = i;
-            foundBottom = true;
+            const DataPoint &dp0 = result[i0];
+            if (dp0.t < t1) break;
         }
 
-        if (dp.z < mWindowTop)
+        if (i0 < 0) break;
+
+        if (dp3.z >= mWindowBottom)
         {
-            top = i;
-            foundTop = false;
+            // Calculate top of window
+            const DataPoint &dp0 = result[i0];
+            const DataPoint &dp2 = result[i0 + 1];
+            DataPoint dp1 = DataPoint::interpolate(
+                        dp0, dp2, (t1 - dp0.t) / (dp2.t - dp0.t));
+
+            const double thisScore = (dp1.z - dp3.z) / (dp3.t - dp1.t);
+            if (thisScore > maxScore)
+            {
+                dpBottom = dp3;
+                dpTop = dp1;
+                maxScore = thisScore;
+                found = true;
+            }
         }
 
-        if (dp.z > mWindowTop)
-        {
-            foundTop = true;
-        }
-
-        if (dp.t < 0) break;
+        if (result[i0].t < 0) break;
     }
 
-    if (foundBottom && foundTop)
-    {
-        // Calculate bottom of window
-        const DataPoint &dp1 = result[bottom - 1];
-        const DataPoint &dp2 = result[bottom];
-        dpBottom = DataPoint::interpolate(dp1, dp2, (mWindowBottom - dp1.z) / (dp2.z - dp1.z));
-
-        // Calculate top of window
-        const DataPoint &dp3 = result[top - 1];
-        const DataPoint &dp4 = result[top];
-        dpTop = DataPoint::interpolate(dp3, dp4, (mWindowTop - dp3.z) / (dp4.z - dp3.z));
-
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return found;
 }

--- a/src/speedscoring.h
+++ b/src/speedscoring.h
@@ -33,9 +33,8 @@ class SpeedScoring : public ScoringMethod
 public:
     SpeedScoring(MainWindow *mainWindow);
 
-    double windowTop(void) const { return mWindowTop; }
     double windowBottom(void) const { return mWindowBottom; }
-    void setWindow(double windowBottom, double windowTop);
+    void setWindow(double windowBottom);
 
     double score(const MainWindow::DataPoints &result);
     QString scoreAsText(double score);
@@ -50,7 +49,6 @@ public:
 private:
     MainWindow *mMainWindow;
 
-    double      mWindowTop;
     double      mWindowBottom;
 
 signals:


### PR DESCRIPTION
This change implements the new scoring method for Speed Skydiving, based on the 2019 Competition Rules available here:

https://www.fai.org/sites/default/files/documents/2019_ipc_cr_speedskydiving.pdf

In addition, some details have been filled in by discussion with the Speed Skydiving committee. In particular, only measured samples are considered, and those samples are only considered if the difference between them is exactly 3.00 seconds. Scoring starts with the first sample after exit and ends with the last sample above 1700 m AGL.