### PR TITLE
Remove dependency on wwWidgets

### DIFF
--- a/src/FlySightViewer.pro
+++ b/src/FlySightViewer.pro
@@ -14,6 +14,7 @@ TARGET = FlySightViewer
 TEMPLATE = app
 
 SOURCES += main.cpp \
+    colorcombobox.cpp \
     mainwindow.cpp \
     dataplot.cpp \
     dataview.cpp \
@@ -87,6 +88,7 @@ SOURCES += main.cpp \
     QCustomPlot/qcustomplot.cpp
 
 HEADERS  += mainwindow.h \
+    colorcombobox.h \
     datapoint.h \
     dataplot.h \
     dataview.h \
@@ -147,25 +149,21 @@ RESOURCES += \
     resource.qrc
 
 INCLUDEPATH += ../include
-INCLUDEPATH += ../include/wwWidgets
 INCLUDEPATH += ../include/GeographicLib
 
 win32 {
     LIBS += -L../lib
     LIBS += -lVLCQtCore -l VLCQtQml -lVLCQtWidgets
-    LIBS += -lwwwidgets4
 }
 else:macx {
     QMAKE_LFLAGS += -F../frameworks
     LIBS         += -framework VLCQtCore
     LIBS         += -framework VLCQtQml
     LIBS         += -framework VLCQtWidgets
-    LIBS         += -framework wwwidgets4
 }
 else {
     LIBS += -L/usr/local/lib
     LIBS += -lvlc-qt -lvlc-qt-widgets
-    LIBS += -lwwwidgets4
 }
 
 macx {

--- a/src/colorcombobox.cpp
+++ b/src/colorcombobox.cpp
@@ -1,0 +1,37 @@
+#include "colorcombobox.h"
+
+ColorComboBox::ColorComboBox(QWidget *parent) : QComboBox(parent)
+{
+    populateList();
+}
+
+QSize ColorComboBox::sizeHint() const
+{
+    return minimumSizeHint();
+}
+
+QSize ColorComboBox::minimumSizeHint() const
+{
+    return QSize(0, QComboBox::minimumSizeHint().height());
+}
+
+QColor ColorComboBox::color() const
+{
+    return qvariant_cast<QColor>(itemData(currentIndex(), Qt::DecorationRole));
+}
+
+void ColorComboBox::setColor(QColor color)
+{
+    setCurrentIndex(findData(color, int(Qt::DecorationRole)));
+}
+
+void ColorComboBox::populateList()
+{
+    QStringList colorNames = QColor::colorNames();
+
+    for (int i = 0; i < colorNames.size(); ++i) {
+        QColor color(colorNames[i]);
+        insertItem(i, colorNames[i]);
+        setItemData(i, color, Qt::DecorationRole);
+    }
+}

--- a/src/colorcombobox.h
+++ b/src/colorcombobox.h
@@ -1,0 +1,24 @@
+#ifndef COLORCOMBOBOX_H
+#define COLORCOMBOBOX_H
+
+#include <QComboBox>
+
+class ColorComboBox : public QComboBox
+{
+    Q_OBJECT
+
+public:
+    explicit ColorComboBox(QWidget *parent = 0);
+
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+
+public:
+    QColor color() const;
+    void setColor(QColor c);
+
+private:
+    void populateList();
+};
+
+#endif // COLORCOMBOBOX_H

--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -26,8 +26,8 @@
 
 #include <QComboBox>
 #include <QSettings>
-#include <QwwColorComboBox>
 
+#include "colorcombobox.h"
 #include "dataplot.h"
 #include "mainwindow.h"
 
@@ -167,16 +167,8 @@ void ConfigDialog::updatePlots()
 
         if (!ui->plotTable->cellWidget(i, PLOT_COLUMN_COLOUR))
         {
-            QwwColorComboBox *combo = new QwwColorComboBox();
-            foreach (const QString &colorName, colorNames)
-            {
-                const QColor &color(colorName);
-                combo->addColor(color, colorName);
-                if (color == yValue->color())
-                {
-                    combo->setCurrentText(colorName);
-                }
-            }
+            ColorComboBox *combo = new ColorComboBox;
+            combo->setColor(yValue->color());
             ui->plotTable->setCellWidget(i, PLOT_COLUMN_COLOUR, combo);
         }
 
@@ -326,8 +318,9 @@ int ConfigDialog::simulationTime() const
 QColor ConfigDialog::plotColor(
         int i) const
 {
-    QComboBox *combo = (QComboBox *) ui->plotTable->cellWidget(i, PLOT_COLUMN_COLOUR);
-    return QColor(combo->currentText());
+    ColorComboBox *combo;
+    combo = static_cast< ColorComboBox* >(ui->plotTable->cellWidget(i, PLOT_COLUMN_COLOUR));
+    return combo->color();
 }
 
 double ConfigDialog::plotMinimum(


### PR DESCRIPTION
Previously we've used wwWidgets for the plot colour picker in preferences. However, this package is no longer supported, so we've moved to our own custom widget instead.