### PR TITLE
Add option to load from raw file every time

### DIFF
--- a/src/configdialog.cpp
+++ b/src/configdialog.cpp
@@ -386,6 +386,18 @@ double ConfigDialog::windDirection() const
     return ui->windDirectionEdit->text().toDouble();
 }
 
+void ConfigDialog::setUseDatabase(
+        bool use)
+{
+    ui->useLogbookButton->setChecked(use);
+    ui->dontUseLogbookButton->setChecked(!use);
+}
+
+bool ConfigDialog::useDatabase() const
+{
+    return (ui->useLogbookButton->isChecked());
+}
+
 void ConfigDialog::setDatabasePath(
         QString databasePath)
 {

--- a/src/configdialog.h
+++ b/src/configdialog.h
@@ -94,6 +94,9 @@ public:
     void setWindDirection(double dir);
     double windDirection() const;
 
+    void setUseDatabase(bool use);
+    bool useDatabase() const;
+
     void setDatabasePath(QString databasePath);
     QString databasePath() const;
 

--- a/src/configdialog.ui
+++ b/src/configdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>315</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -187,7 +187,30 @@
             </widget>
            </item>
            <item>
-            <spacer name="verticalSpacer_4">
+            <widget class="QGroupBox" name="groupBox_3">
+             <property name="title">
+              <string>Logbook</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+              <item>
+               <widget class="QRadioButton" name="useLogbookButton">
+                <property name="text">
+                 <string>Import tracks from logbook if available</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="dontUseLogbookButton">
+                <property name="text">
+                 <string>Import tracks from selected file every time</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <spacer name="verticalSpacer_2">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -312,6 +312,8 @@ private:
     GroundReference       mGroundReference;
     double                mFixedReference;
 
+    bool                  mUseDatabase;
+
     QString               mDatabasePath;
     QSqlDatabase          mDatabase;
 


### PR DESCRIPTION
Previously, FlySight Viewer would always load files from the logbook if available. However, some users found this confusing and preferred to load always as though it were the first time. The new option in Preferences allows users to choose this behaviour.