### PR TITLE
Speed scoring update

### DIFF
--- a/src/acroform.ui
+++ b/src/acroform.ui
@@ -35,14 +35,14 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Speed Threshold:</string>
+           <string>Speed threshold:</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_5">
           <property name="text">
-           <string>Altitude Window:</string>
+           <string>Altitude window:</string>
           </property>
          </widget>
         </item>
@@ -109,7 +109,7 @@
         <item>
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Working Time:</string>
+           <string>Working time:</string>
           </property>
          </widget>
         </item>

--- a/src/ppcform.ui
+++ b/src/ppcform.ui
@@ -256,7 +256,7 @@
         <item row="2" column="0">
          <widget class="QRadioButton" name="hSpeedButton">
           <property name="text">
-           <string>H. Speed:</string>
+           <string>Horizontal speed:</string>
           </property>
          </widget>
         </item>

--- a/src/speedform.cpp
+++ b/src/speedform.cpp
@@ -44,6 +44,7 @@ SpeedForm::SpeedForm(QWidget *parent) :
 
     connect(ui->fromExitEdit, SIGNAL(editingFinished()), this, SLOT(onApplyButtonClicked()));
     connect(ui->bottomEdit, SIGNAL(editingFinished()), this, SLOT(onApplyButtonClicked()));
+    connect(ui->validationEdit, SIGNAL(editingFinished()), this, SLOT(onApplyButtonClicked()));
 
     // Connect optimization buttons
     connect(ui->actualButton, SIGNAL(clicked()), this, SLOT(onActualButtonClicked()));
@@ -83,10 +84,12 @@ void SpeedForm::updateView()
 
     const double fromExit = method->fromExit();
     const double bottom = method->windowBottom();
+    const double validationWindow = method->validationWindow();
 
     // Update window bounds
     ui->fromExitEdit->setText(QString("%1").arg(fromExit * METERS_TO_FEET));
     ui->bottomEdit->setText(QString("%1").arg(bottom * METERS_TO_FEET));
+    ui->validationEdit->setText(QString("%1").arg(validationWindow * METERS_TO_FEET));
 
     // Get exit
     DataPoint dpExit = mMainWindow->interpolateDataT(0);
@@ -94,10 +97,14 @@ void SpeedForm::updateView()
     DataPoint dpBottom, dpTop;
     bool success;
 
+    double speedAccuracy;
+    bool accuracyOkay = false;
+
     switch (mMainWindow->windowMode())
     {
     case MainWindow::Actual:
         success = method->getWindowBounds(mMainWindow->data(), dpBottom, dpTop, dpExit);
+        accuracyOkay = method->getAccuracy(mMainWindow->data(), speedAccuracy, dpExit);
         break;
     case MainWindow::Optimal:
         success = method->getWindowBounds(mMainWindow->optimal(), dpBottom, dpTop, dpExit);
@@ -144,23 +151,37 @@ void SpeedForm::updateView()
         ui->optimizeButton->setEnabled(false);
         ui->ppcButton->setEnabled(false);
     }
+
+    if (accuracyOkay)
+    {
+        ui->accuracyEdit->setText(QString("%1").arg(speedAccuracy));
+    }
+    else
+    {
+        ui->accuracyEdit->setText(tr("n/a"));
+    }
 }
 
 void SpeedForm::onFAIButtonClicked()
 {
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
+
     method->setFromExit(2255.52);
     method->setWindowBottom(1706.88);
+    method->setValidationWindow(1005.84);
 }
 
 void SpeedForm::onApplyButtonClicked()
 {
     double fromExit = ui->fromExitEdit->text().toDouble() / METERS_TO_FEET;
     double bottom = ui->bottomEdit->text().toDouble() / METERS_TO_FEET;
+    double validationWindow = ui->validationEdit->text().toDouble() / METERS_TO_FEET;
 
     SpeedScoring *method = (SpeedScoring *) mMainWindow->scoringMethod(MainWindow::Speed);
+
     method->setFromExit(fromExit);
     method->setWindowBottom(bottom);
+    method->setValidationWindow(validationWindow);
 
     mMainWindow->setFocus();
 }

--- a/src/speedform.cpp
+++ b/src/speedform.cpp
@@ -97,14 +97,14 @@ void SpeedForm::updateView()
     DataPoint dpBottom, dpTop;
     bool success;
 
-    double speedAccuracy;
+    double vAcc, sAcc, numSV;
     bool accuracyOkay = false;
 
     switch (mMainWindow->windowMode())
     {
     case MainWindow::Actual:
         success = method->getWindowBounds(mMainWindow->data(), dpBottom, dpTop, dpExit);
-        accuracyOkay = method->getAccuracy(mMainWindow->data(), speedAccuracy, dpExit);
+        accuracyOkay = method->getAccuracy(mMainWindow->data(), vAcc, sAcc, numSV, dpExit);
         break;
     case MainWindow::Optimal:
         success = method->getWindowBounds(mMainWindow->optimal(), dpBottom, dpTop, dpExit);
@@ -154,11 +154,15 @@ void SpeedForm::updateView()
 
     if (accuracyOkay)
     {
-        ui->accuracyEdit->setText(QString("%1").arg(speedAccuracy));
+        ui->vAccEdit->setText(QString("%1").arg(vAcc, 0, 'f', 3));
+        ui->sAccEdit->setText(QString("%1").arg(sAcc, 0, 'f', 2));
+        ui->numSVEdit->setText(QString("%1").arg(numSV, 0, 'f', 0));
     }
     else
     {
-        ui->accuracyEdit->setText(tr("n/a"));
+        ui->vAccEdit->setText(tr("n/a"));
+        ui->sAccEdit->setText(tr("n/a"));
+        ui->numSVEdit->setText(tr("n/a"));
     }
 }
 

--- a/src/speedform.cpp
+++ b/src/speedform.cpp
@@ -97,14 +97,14 @@ void SpeedForm::updateView()
     DataPoint dpBottom, dpTop;
     bool success;
 
-    double vAcc, sAcc, numSV;
+    double scoreAccuracy;
     bool accuracyOkay = false;
 
     switch (mMainWindow->windowMode())
     {
     case MainWindow::Actual:
         success = method->getWindowBounds(mMainWindow->data(), dpBottom, dpTop, dpExit);
-        accuracyOkay = method->getAccuracy(mMainWindow->data(), vAcc, sAcc, numSV, dpExit);
+        accuracyOkay = method->getAccuracy(mMainWindow->data(), scoreAccuracy, dpExit);
         break;
     case MainWindow::Optimal:
         success = method->getWindowBounds(mMainWindow->optimal(), dpBottom, dpTop, dpExit);
@@ -120,12 +120,12 @@ void SpeedForm::updateView()
         // Update display
         if (mMainWindow->units() == PlotValue::Metric)
         {
-            ui->verticalSpeedEdit->setText(QString("%1").arg(verticalSpeed * MPS_TO_KMH));
+            ui->verticalSpeedEdit->setText(QString("%1").arg(verticalSpeed * MPS_TO_KMH, 0, 'f', 2));
             ui->verticalSpeedUnits->setText(tr("km/h"));
         }
         else
         {
-            ui->verticalSpeedEdit->setText(QString("%1").arg(verticalSpeed * MPS_TO_MPH));
+            ui->verticalSpeedEdit->setText(QString("%1").arg(verticalSpeed * MPS_TO_MPH, 0, 'f', 2));
             ui->verticalSpeedUnits->setText(tr("mph"));
         }
         ui->actualButton->setEnabled(true);
@@ -154,15 +154,11 @@ void SpeedForm::updateView()
 
     if (accuracyOkay)
     {
-        ui->vAccEdit->setText(QString("%1").arg(vAcc, 0, 'f', 3));
-        ui->sAccEdit->setText(QString("%1").arg(sAcc, 0, 'f', 2));
-        ui->numSVEdit->setText(QString("%1").arg(numSV, 0, 'f', 0));
+        ui->scoreAccuracyEdit->setText(QString("%1").arg(scoreAccuracy, 0, 'f', 2));
     }
     else
     {
-        ui->vAccEdit->setText(tr("n/a"));
-        ui->sAccEdit->setText(tr("n/a"));
-        ui->numSVEdit->setText(tr("n/a"));
+        ui->scoreAccuracyEdit->setText(tr("n/a"));
     }
 }
 

--- a/src/speedform.ui
+++ b/src/speedform.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>265</width>
-    <height>300</height>
+    <height>378</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,12 +25,19 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>From Exit:</string>
+           <string>Performance Window:</string>
           </property>
          </widget>
         </item>
         <item row="0" column="1">
          <widget class="QLineEdit" name="fromExitEdit"/>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="bottomUnits">
+          <property name="text">
+           <string>ft</string>
+          </property>
+         </widget>
         </item>
         <item row="0" column="2">
          <widget class="QLabel" name="bottomUnits_2">
@@ -39,18 +46,28 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Bottom:</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1">
          <widget class="QLineEdit" name="bottomEdit"/>
         </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="bottomUnits">
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Breakoff Altitude:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Validation Window:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="validationEdit"/>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLabel" name="label_5">
           <property name="text">
            <string>ft</string>
           </property>
@@ -106,13 +123,6 @@
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="2">
-         <widget class="QLabel" name="verticalSpeedUnits">
-          <property name="text">
-           <string>km/h</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QLineEdit" name="verticalSpeedEdit">
           <property name="readOnly">
@@ -120,12 +130,36 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="verticalSpeedUnits">
+          <property name="text">
+           <string>km/h</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>V. Speed:</string>
+           <string>Vertical Speed:</string>
           </property>
          </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Speed Accuracy:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>m/s</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="accuracyEdit"/>
         </item>
        </layout>
       </item>

--- a/src/speedform.ui
+++ b/src/speedform.ui
@@ -157,49 +157,22 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="1" column="2">
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="scoreAccuracyEdit"/>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Speed accuracy:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>m/s</string>
           </property>
          </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Worst vertical accuracy:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Worst speed accuracy:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="sAccEdit"/>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="vAccEdit"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>m</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>Lowest number of satellites:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="numSVEdit"/>
         </item>
        </layout>
       </item>

--- a/src/speedform.ui
+++ b/src/speedform.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>265</width>
-    <height>378</height>
+    <height>465</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -25,7 +25,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Performance Window:</string>
+           <string>Performance window:</string>
           </property>
          </widget>
         </item>
@@ -52,14 +52,14 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Breakoff Altitude:</string>
+           <string>Breakoff altitude:</string>
           </property>
          </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
-           <string>Validation Window:</string>
+           <string>Validation window:</string>
           </property>
          </widget>
         </item>
@@ -122,11 +122,18 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QGridLayout" name="gridLayout_2">
+       <layout class="QGridLayout" name="gridLayout_4">
         <item row="0" column="1">
          <widget class="QLineEdit" name="verticalSpeedEdit">
           <property name="readOnly">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Vertical speed:</string>
           </property>
          </widget>
         </item>
@@ -137,29 +144,62 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Vertical Speed:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Speed Accuracy:</string>
-          </property>
-         </widget>
-        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Validation window</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout_3">
         <item row="1" column="2">
-         <widget class="QLabel" name="label_7">
+         <widget class="QLabel" name="label_8">
           <property name="text">
            <string>m/s</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Worst vertical accuracy:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Worst speed accuracy:</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="accuracyEdit"/>
+         <widget class="QLineEdit" name="sAccEdit"/>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="vAccEdit"/>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>m</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Lowest number of satellites:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="numSVEdit"/>
         </item>
        </layout>
       </item>

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -32,7 +32,8 @@ SpeedScoring::SpeedScoring(
     ScoringMethod(mainWindow),
     mMainWindow(mainWindow),
     mFromExit(2255.52),
-    mWindowBottom(1706.88)
+    mWindowBottom(1706.88),
+    mValidationWindow(1005.84)
 {
 
 }
@@ -48,6 +49,13 @@ void SpeedScoring::setWindowBottom(
         double windowBottom)
 {
     mWindowBottom = windowBottom;
+    emit scoringChanged();
+}
+
+void SpeedScoring::setValidationWindow(
+        double validationWindow)
+{
+    mValidationWindow = validationWindow;
     emit scoringChanged();
 }
 
@@ -201,6 +209,38 @@ bool SpeedScoring::getWindowBounds(
             dpBottom = dpEnd;
             dpTop = dpStart;
             maxScore = thisScore;
+            found = true;
+        }
+    }
+
+    return found;
+}
+
+bool SpeedScoring::getAccuracy(
+        const MainWindow::DataPoints &result,
+        double &accuracy,
+        const DataPoint &dpExit)
+{
+    bool found = false;
+
+    for (int i = result.size() - 1; i >= 0; --i)
+    {
+        // Get end point
+        const DataPoint &dp = result[i];
+
+        // Get validation window
+        const double zBottom = qMax(dpExit.z - mFromExit, mWindowBottom);
+        const double zTop = zBottom + mValidationWindow;
+
+        // Check window conditions
+        if (dp.t < 0) break;
+        if (dp.z < zBottom) continue;
+        if (dp.z > zTop) continue;
+
+        // Calculate accuracy
+        if ((!found) || (dp.sAcc > accuracy))
+        {
+            accuracy = dp.sAcc;
             found = true;
         }
     }

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -26,6 +26,7 @@
 #include "mainwindow.h"
 
 #define TIME_DELTA 0.005
+#define SQRT_2 1.41421356237
 
 SpeedScoring::SpeedScoring(
         MainWindow *mainWindow):
@@ -218,9 +219,7 @@ bool SpeedScoring::getWindowBounds(
 
 bool SpeedScoring::getAccuracy(
         const MainWindow::DataPoints &result,
-        double &vAcc,
-        double &sAcc,
-        double &numSV,
+        double &scoreAccuracy,
         const DataPoint &dpExit)
 {
     bool found = false;
@@ -240,17 +239,10 @@ bool SpeedScoring::getAccuracy(
         if (dp.z > zTop) continue;
 
         // Calculate accuracy
-        if ((!found) || (dp.vAcc > vAcc))
+        double sa = 1.960 * SQRT_2 * dp.vAcc / 3.0;
+        if ((!found) || (sa > scoreAccuracy))
         {
-            vAcc = dp.vAcc;
-        }
-        if ((!found) || (dp.sAcc > sAcc))
-        {
-            sAcc = dp.sAcc;
-        }
-        if ((!found) || (dp.numSV < numSV))
-        {
-            numSV = dp.numSV;
+            scoreAccuracy = sa;
         }
 
         found = true;

--- a/src/speedscoring.cpp
+++ b/src/speedscoring.cpp
@@ -218,7 +218,9 @@ bool SpeedScoring::getWindowBounds(
 
 bool SpeedScoring::getAccuracy(
         const MainWindow::DataPoints &result,
-        double &accuracy,
+        double &vAcc,
+        double &sAcc,
+        double &numSV,
         const DataPoint &dpExit)
 {
     bool found = false;
@@ -238,11 +240,20 @@ bool SpeedScoring::getAccuracy(
         if (dp.z > zTop) continue;
 
         // Calculate accuracy
-        if ((!found) || (dp.sAcc > accuracy))
+        if ((!found) || (dp.vAcc > vAcc))
         {
-            accuracy = dp.sAcc;
-            found = true;
+            vAcc = dp.vAcc;
         }
+        if ((!found) || (dp.sAcc > sAcc))
+        {
+            sAcc = dp.sAcc;
+        }
+        if ((!found) || (dp.numSV < numSV))
+        {
+            numSV = dp.numSV;
+        }
+
+        found = true;
     }
 
     return found;

--- a/src/speedscoring.h
+++ b/src/speedscoring.h
@@ -39,6 +39,9 @@ public:
     double windowBottom(void) const { return mWindowBottom; }
     void setWindowBottom(double windowBottom);
 
+    double validationWindow(void) const { return mValidationWindow; }
+    void setValidationWindow(double validationWindow);
+
     double score(const MainWindow::DataPoints &result);
     QString scoreAsText(double score);
 
@@ -47,6 +50,9 @@ public:
     bool getWindowBounds(const MainWindow::DataPoints &result,
                          DataPoint &dpBottom, DataPoint &dpTop,
                          const DataPoint &dpExit);
+    bool getAccuracy(const MainWindow::DataPoints &result,
+                     double &accuracy,
+                     const DataPoint &dpExit);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }
 
@@ -55,6 +61,7 @@ private:
 
     double      mFromExit;
     double      mWindowBottom;
+    double      mValidationWindow;
 
 signals:
 

--- a/src/speedscoring.h
+++ b/src/speedscoring.h
@@ -51,7 +51,7 @@ public:
                          DataPoint &dpBottom, DataPoint &dpTop,
                          const DataPoint &dpExit);
     bool getAccuracy(const MainWindow::DataPoints &result,
-                     double &accuracy,
+                     double &vAcc, double &sAcc, double &numSV,
                      const DataPoint &dpExit);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }

--- a/src/speedscoring.h
+++ b/src/speedscoring.h
@@ -51,7 +51,7 @@ public:
                          DataPoint &dpBottom, DataPoint &dpTop,
                          const DataPoint &dpExit);
     bool getAccuracy(const MainWindow::DataPoints &result,
-                     double &vAcc, double &sAcc, double &numSV,
+                     double &scoreAccuracy,
                      const DataPoint &dpExit);
 
     void optimize() { ScoringMethod::optimize(mMainWindow, mWindowBottom); }


### PR DESCRIPTION
Implement validation window check for Speed Skydiving. This estimates the worst score accuracy (95% confidence) within the validation window as follows:

score_error = 1.960 * sqrt(2) * vAcc / (3 seconds)

According to the 2021 rules, this should be less than 3 m/s for every point in the validation window.

The validation window is 3,300 ft (1,006 m) in length, the end of which is determined by the end of the performance window.

The performance window is the scoring part of the speed jump, which starts at exit. The end of the performance window is either 7,400 ft (2,256 m) below exit or at Breakoff altitude whichever is reached first.

Breakoff altitude is set at 5,600 ft (1,707 m). Below the breakoff altitude no speed measurements are taken into account.

In FlySight Viewer, the performance window starts at exit and ends a fixed distance below exit, as determined by the scoring interface. Breakoff altitude is also determined by the scoring interface.